### PR TITLE
Perf/speedup trainer jit caching

### DIFF
--- a/src/energnn/trainer/trainer.py
+++ b/src/energnn/trainer/trainer.py
@@ -48,30 +48,9 @@ def _cast_cotangent_to_primal_dtype(cotangent_pytree, primal_pytree):
     return jax.tree.map(_cast_leaf, cotangent_pytree, primal_pytree)
 
 
-def _update_params(optimizer: nnx.Optimizer, model: GNN, gradient: nnx.State, get_info: bool) -> dict:
-    r"""
-    Updates the model weights using the gradient.
-
-    :param optimizer: Optimizer instance.
-    :param model: Core Graph Neural Network model.
-    :param gradient: Gradient for model parameters.
-    :param get_info: If True, return diagnostic info on grads and updates.
-    :returns: Dictionary of diagnostic information.
-    """
-
-    def update_params(optimizer, model, gradient):
-        optimizer.update(model, gradient)
-
-    nnx.jit(update_params)(optimizer, model, gradient)
-
-    if get_info:
-        infos = {
-            # "grads/l2_norm": optax.tree_utils.tree_l2_norm(grads),
-        }
-    else:
-        infos = {}
-
-    return infos
+def _update_params_fn(optimizer: nnx.Optimizer, model: GNN, gradient: nnx.State) -> None:
+    """JIT-compatible function that applies the optimizer update."""
+    optimizer.update(model, gradient)
 
 
 def _setup_ckpt_mngr(checkpoint_manager: CheckpointManager, optim_mode: Literal["minimize", "maximize"]):
@@ -120,6 +99,31 @@ class Trainer:
         self.optimizer = nnx.Optimizer(self.model, gradient_transformation, wrt=nnx.Param)
         self.train_step: int = 0
         self.best_score: float | None = None
+
+        # Cache JIT-compiled wrappers to avoid NNX re-tracing overhead each step.
+        # `get_info` is static because downstream code branches on its concrete value.
+        self._jit_apply = nnx.jit(self._apply_forward_vjp, static_argnames=("get_info",))
+        self._jit_eval_forward = nnx.jit(self._eval_forward)
+        self._jit_update_params = nnx.jit(_update_params_fn)
+
+    @staticmethod
+    def _apply_forward_vjp(graphdef, params, rest, jax_context, get_info):
+        """Forward pass + VJP setup, designed to be JIT-compiled once and reused."""
+        def f_forward(p, r):
+            model = nnx.merge(graphdef, p, r)
+            decision, _ = model.forward_batch(graph=jax_context, get_info=get_info)
+            _, _, r_updated = nnx.split(model, nnx.Param, ...)
+            return decision, r_updated
+
+        (jax_decision, rest_updated), vjp_fn = jax.vjp(f_forward, params, rest)
+        return jax_decision, rest_updated, vjp_fn
+
+    @staticmethod
+    def _eval_forward(model, context):
+        """Forward pass for evaluation, designed to be JIT-compiled once and reused."""
+        decision, info = model.forward_batch(graph=context, get_info=True)
+        _, _, r_updated = nnx.split(model, nnx.Param, ...)
+        return decision, info, r_updated
 
     def train(
         self,
@@ -340,37 +344,23 @@ class Trainer:
             infos = {}
             jax_context, infos["1_context"] = problem_batch.get_context(get_info=get_info, step=self.train_step)
 
-            def apply(params, rest, jax_context):
-                def f_forward(p, r):
-                    model = nnx.merge(graphdef, p, r)
-                    decision, _ = model.forward_batch(graph=jax_context, get_info=get_info)
-                    _, _, r_updated = nnx.split(model, nnx.Param, ...)
-                    return decision, r_updated
-
-                (jax_decision, rest_updated), vjp_fn = jax.vjp(f_forward, params, rest)
-                return jax_decision, rest_updated, vjp_fn
-
             graphdef, params, rest = nnx.split(self.model, nnx.Param, ...)
-            jax_decision, rest_updated, vjp_fn = nnx.jit(apply)(params, rest, jax_context)
-
-            def model_vjp(cotangent):
-                # We only care about the cotangent of the decision, not the rest
-                rest_cotangent = jax.tree.map(jnp.zeros_like, rest_updated)
-                (grads_params, _) = vjp_fn((cotangent, rest_cotangent))
-                return (grads_params,)
+            jax_decision, rest_updated, vjp_fn = self._jit_apply(
+                graphdef, params, rest, jax_context, get_info
+            )
 
             nnx.update(self.model, rest_updated)
             jax_gradient, infos["3_gradient"] = problem_batch.get_gradient(
                 decision=jax_decision, get_info=get_info, step=self.train_step
             )
             jax_cotangent = _cast_cotangent_to_primal_dtype(jax_gradient, jax_decision)
-            (grads_params,) = model_vjp(jax_cotangent)
-            infos["4_update"] = _update_params(
-                optimizer=self.optimizer,
-                model=self.model,
-                gradient=grads_params,
-                get_info=get_info,
-            )
+
+            # Backward pass
+            rest_cotangent = jax.tree.map(jnp.zeros_like, rest_updated)
+            (grads_params, _) = vjp_fn((jax_cotangent, rest_cotangent))
+
+            self._jit_update_params(self.optimizer, self.model, grads_params)
+            infos["4_update"] = {}
 
         # Flatten and numpify infos
         infos = flatdict.FlatDict(infos, delimiter="/")
@@ -390,12 +380,9 @@ class Trainer:
 
             jax_context, infos["1_context"] = problem_batch.get_context(get_info=True, step=self.train_step)
 
-            def f(model, context):
-                decision, info = model.forward_batch(graph=context, get_info=True)
-                _, _, r_updated = nnx.split(model, nnx.Param, ...)
-                return decision, info, r_updated
-
-            jax_decision, infos["2_forward"], rest_updated = nnx.jit(f)(model=self.model, context=jax_context)
+            jax_decision, infos["2_forward"], rest_updated = self._jit_eval_forward(
+                model=self.model, context=jax_context
+            )
 
             score, infos["3_score"] = problem_batch.get_score(decision=jax_decision, get_info=True, step=self.train_step)
 

--- a/src/energnn/trainer/trainer.py
+++ b/src/energnn/trainer/trainer.py
@@ -109,6 +109,7 @@ class Trainer:
     @staticmethod
     def _apply_forward_vjp(graphdef, params, rest, jax_context, get_info):
         """Forward pass + VJP setup, designed to be JIT-compiled once and reused."""
+
         def f_forward(p, r):
             model = nnx.merge(graphdef, p, r)
             decision, _ = model.forward_batch(graph=jax_context, get_info=get_info)
@@ -345,9 +346,7 @@ class Trainer:
             jax_context, infos["1_context"] = problem_batch.get_context(get_info=get_info, step=self.train_step)
 
             graphdef, params, rest = nnx.split(self.model, nnx.Param, ...)
-            jax_decision, rest_updated, vjp_fn = self._jit_apply(
-                graphdef, params, rest, jax_context, get_info
-            )
+            jax_decision, rest_updated, vjp_fn = self._jit_apply(graphdef, params, rest, jax_context, get_info)
 
             nnx.update(self.model, rest_updated)
             jax_gradient, infos["3_gradient"] = problem_batch.get_gradient(
@@ -380,9 +379,7 @@ class Trainer:
 
             jax_context, infos["1_context"] = problem_batch.get_context(get_info=True, step=self.train_step)
 
-            jax_decision, infos["2_forward"], rest_updated = self._jit_eval_forward(
-                model=self.model, context=jax_context
-            )
+            jax_decision, infos["2_forward"], rest_updated = self._jit_eval_forward(model=self.model, context=jax_context)
 
             score, infos["3_score"] = problem_batch.get_score(decision=jax_decision, get_info=True, step=self.train_step)
 

--- a/tests/trainer/unit/test_simple_trainer.py
+++ b/tests/trainer/unit/test_simple_trainer.py
@@ -273,24 +273,16 @@ class TestJitCaching:
         return create_tiny_model(loader.context_structure)
 
     @pytest.mark.parametrize("get_info", [True, False])
-    def test_apply_forward_vjp_roundtrip(
-        self, model: GNN, batch: ProblemBatch, get_info: bool
-    ) -> None:
+    def test_apply_forward_vjp_roundtrip(self, model: GNN, batch: ProblemBatch, get_info: bool) -> None:
         """_apply_forward_vjp returns a vjp_fn whose gradient tree matches params, for both get_info branches."""
         jax_context, _ = batch.get_context(get_info=get_info, step=0)
         graphdef, params, rest = nnx.split(model, nnx.Param, ...)
 
-        decision, rest_updated, vjp_fn = Trainer._apply_forward_vjp(
-            graphdef, params, rest, jax_context, get_info
-        )
-        (grads, _) = vjp_fn(
-            (jax.tree.map(jnp.zeros_like, decision), jax.tree.map(jnp.zeros_like, rest_updated))
-        )
+        decision, rest_updated, vjp_fn = Trainer._apply_forward_vjp(graphdef, params, rest, jax_context, get_info)
+        (grads, _) = vjp_fn((jax.tree.map(jnp.zeros_like, decision), jax.tree.map(jnp.zeros_like, rest_updated)))
         assert jax.tree.structure(grads) == jax.tree.structure(params)
 
-    def test_params_change_and_stay_finite_across_steps(
-        self, model: GNN, batch: ProblemBatch
-    ) -> None:
+    def test_params_change_and_stay_finite_across_steps(self, model: GNN, batch: ProblemBatch) -> None:
         """Repeated training_step calls mutate params and keep values finite."""
         trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-1))
         before = [jnp.array(x) for x in jax.tree.leaves(nnx.state(model, nnx.Param))]
@@ -302,9 +294,7 @@ class TestJitCaching:
         assert all(jnp.all(jnp.isfinite(x)) for x in after)
         assert any(not jnp.allclose(b, a) for b, a in zip(before, after))
 
-    def test_apply_forward_vjp_traced_once_across_steps(
-        self, model: GNN, batch: ProblemBatch
-    ) -> None:
+    def test_apply_forward_vjp_traced_once_across_steps(self, model: GNN, batch: ProblemBatch) -> None:
         """_apply_forward_vjp's Python body runs exactly once over repeated training steps."""
         trace_count = [0]
         original = Trainer._apply_forward_vjp

--- a/tests/trainer/unit/test_simple_trainer.py
+++ b/tests/trainer/unit/test_simple_trainer.py
@@ -4,15 +4,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
+from unittest import mock
 from unittest.mock import MagicMock
 
 import jax
 import jax.numpy as jnp
 import optax
+import pytest
 from flax import nnx
 
 from energnn.graph import JaxGraph, JaxHyperEdgeSet
 from energnn.model import GNN, IdentityEncoder
+from energnn.problem import ProblemBatch
 from energnn.problem.example import LinearSystemProblemLoader
 from energnn.trainer import Trainer
 from energnn.trainer.trainer import _cast_cotangent_to_primal_dtype
@@ -252,3 +255,67 @@ def test_train_with_tracker_and_storage():
     # m_cp.wait_until_finished should be called at the end of train
     assert m_cp.wait_until_finished.called
     assert m_cp._options.best_mode == "min"
+
+
+class TestJitCaching:
+    """Tests for Trainer's JIT-cached training and evaluation pathways."""
+
+    @pytest.fixture(scope="class")
+    def loader(self) -> LinearSystemProblemLoader:
+        return LinearSystemProblemLoader(dataset_size=4, batch_size=4)
+
+    @pytest.fixture(scope="class")
+    def batch(self, loader: LinearSystemProblemLoader) -> ProblemBatch:
+        return next(iter(loader))
+
+    @pytest.fixture
+    def model(self, loader: LinearSystemProblemLoader) -> GNN:
+        return create_tiny_model(loader.context_structure)
+
+    @pytest.mark.parametrize("get_info", [True, False])
+    def test_apply_forward_vjp_roundtrip(
+        self, model: GNN, batch: ProblemBatch, get_info: bool
+    ) -> None:
+        """_apply_forward_vjp returns a vjp_fn whose gradient tree matches params, for both get_info branches."""
+        jax_context, _ = batch.get_context(get_info=get_info, step=0)
+        graphdef, params, rest = nnx.split(model, nnx.Param, ...)
+
+        decision, rest_updated, vjp_fn = Trainer._apply_forward_vjp(
+            graphdef, params, rest, jax_context, get_info
+        )
+        (grads, _) = vjp_fn(
+            (jax.tree.map(jnp.zeros_like, decision), jax.tree.map(jnp.zeros_like, rest_updated))
+        )
+        assert jax.tree.structure(grads) == jax.tree.structure(params)
+
+    def test_params_change_and_stay_finite_across_steps(
+        self, model: GNN, batch: ProblemBatch
+    ) -> None:
+        """Repeated training_step calls mutate params and keep values finite."""
+        trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-1))
+        before = [jnp.array(x) for x in jax.tree.leaves(nnx.state(model, nnx.Param))]
+
+        for _ in range(5):
+            trainer.training_step(batch, get_info=False)
+
+        after = jax.tree.leaves(nnx.state(model, nnx.Param))
+        assert all(jnp.all(jnp.isfinite(x)) for x in after)
+        assert any(not jnp.allclose(b, a) for b, a in zip(before, after))
+
+    def test_apply_forward_vjp_traced_once_across_steps(
+        self, model: GNN, batch: ProblemBatch
+    ) -> None:
+        """_apply_forward_vjp's Python body runs exactly once over repeated training steps."""
+        trace_count = [0]
+        original = Trainer._apply_forward_vjp
+
+        def counting(*args, **kwargs):
+            trace_count[0] += 1
+            return original(*args, **kwargs)
+
+        with mock.patch.object(Trainer, "_apply_forward_vjp", staticmethod(counting)):
+            trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-3))
+            for _ in range(5):
+                trainer.training_step(batch, get_info=False)
+
+        assert trace_count[0] == 1


### PR DESCRIPTION
## Summary
Cache JIT-compiled forward+VJP and optimizer-update functions once in `Trainer.__init__` instead of rebuilding them inside every `training_step` /`eval_step`. This eliminates per-step NNX re-tracing overhead.

## Changes
- **Trainer** : The JIT-compiled functions used for the forward pass, the backward pass (VJP), the evaluation forward pass, and the optimizer update are now built once when the `Trainer` is created, and reused for every subsequent training and evaluation step. Previously they were rebuilt inside each step, which forced JAX/NNX to retrace and recompile repeatedly.

- **Tests** : a new test suite covers the cached pathways and verifies:
  1. the forward+VJP path returns a gradient tree matching the model's params under both `get_info=True` and `get_info=False`,
  2. model parameters evolve and stay finite across repeated training steps,
  3. the cached wrapper is traced exactly once across multiple training steps (a direct check that the cache is hit rather than rebuilt.)

## 📌 Benchmarking results with `SmallRecurrentEquivariantGNN` on `LinearSystemProblemLoader`

**TL;DR :** caching in `Trainer` yields a **7.5–12× speedup (≈87–92% faster)** on the training loop, and cuts per-step standard deviation by **14–23× on GPU and 130–230× on CPU**, making step latency far more stable and predictable.


### Methodology
Profiling methodology:
- **Config:** `SmallRecurrentEquivariantGNN` + `LinearSystemProblemLoader(seed=42, dataset_size=32, batch_size=8, n_max=8)` + Adam(lr=1e-3).
- **Protocol:** 5 trials × (5 warmup + 30 measured) steps per configuration; a fresh model+trainer is built for every trial so cross-trial cache state never contaminates the measurement. Each step is timed end-to-end with `jax.block_until_ready` to include async dispatch.
- **Correctness gate:** original vs optimized agree within `max |Δparams| < 1e-5` after 100 identical training steps.

### Detailed Results
#### CPU (Apple M3 Pro)
| `get_info` | Original (ms / step) | Optimized (ms / step) | Speedup | Std reduction |
|---|---|---|---|---|
| `False` | 814.3 ± 261.2  | **68.2 ± 2.0** | **11.9×** | ~130× |
| `True`  | 853.6 ± 389.2  | **68.8 ± 1.7** | **12.4×** | ~230× |

#### GPU (Tesla T4, Colab)
| `get_info` | Original (ms / step) | Optimized (ms / step) | Speedup | Std reduction |
|---|---|---|---|---|
| `False` | 4091.8 ± 709.9  | **543.7 ± 50.9** | **7.5×** | ~14× |
| `True`  | 4309.7 ± 1178.5 | **549.4 ± 50.9** | **7.8×** | ~23× |
