### PR TITLE
Add converter package to build Graphs from domain-specific objects

### DIFF
--- a/docs/reference/converter/index.rst
+++ b/docs/reference/converter/index.rst
@@ -1,0 +1,45 @@
+=========
+Converter
+=========
+
+Converters turn domain-specific objects (e.g. a ``pypowsybl.network.Network``) into
+:class:`~energnn.graph.Graph` instances.
+
+A :class:`~energnn.converter.Converter` is composed of one
+:class:`~energnn.converter.ElementsConverter` per hyper-edge class (e.g. ``"bus"``, ``"line"``),
+each in charge of extracting a table of addresses and features from the input object.
+The converter then maps string addresses to consecutive integers, casts features to bounded
+floats, and assembles the tables into a graph.
+
+.. currentmodule:: energnn.converter
+
+
+Converter
+=========
+
+.. autoclass:: Converter
+   :no-members:
+   :show-inheritance:
+
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   Converter.__call__
+   Converter.get_structure
+
+
+ElementsConverter
+=================
+
+.. autoclass:: ElementsConverter
+   :no-members:
+   :show-inheritance:
+
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   ElementsConverter.__init__
+   ElementsConverter.__call__
+   ElementsConverter.get_structure

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,6 +8,7 @@ of energnn classes and methods.
     :maxdepth: 1
 
     graph/index
+    converter/index
     model/index
     problem/index
     trainer/index

--- a/src/energnn/__init__.py
+++ b/src/energnn/__init__.py
@@ -4,6 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 #
-from energnn import graph, model, problem, tracker, trainer
+from energnn import converter, graph, model, problem, tracker, trainer
 
-__all__ = ["graph", "model", "problem", "tracker", "trainer"]
+__all__ = ["converter", "graph", "model", "problem", "tracker", "trainer"]

--- a/src/energnn/converter/__init__.py
+++ b/src/energnn/converter/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+from .core import Converter
+from .element_converter import ElementsConverter
+
+__all__ = ["Converter", "ElementsConverter"]

--- a/src/energnn/converter/core.py
+++ b/src/energnn/converter/core.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+import random
+
+import numpy as np
+import pandas as pd
+
+from energnn.graph import Graph, GraphStructure, HyperEdgeSet
+from energnn.graph.backend import Backend, NumpyBackend
+from .element_converter import ElementsConverter
+
+
+class Converter:
+    """Abstract base class for all converters.
+
+    A converter turns a domain-specific object (e.g. a ``pypowsybl.network.Network``) into an
+    :class:`energnn.graph.Graph`. Subclasses only need to provide ``elements_converter_dict``,
+    which maps each hyper-edge class name (e.g. ``"bus"``, ``"line"``) to the
+    :class:`ElementsConverter` in charge of extracting its table of addresses and features.
+
+    Calling the converter runs the following pipeline:
+
+    1. each :class:`ElementsConverter` extracts an ``(address table, feature table)`` pair from
+       the input object;
+    2. string addresses are mapped to consecutive integers ``0..n-1``, in sorted order so that
+       the mapping is reproducible across runs;
+    3. features are cast to floats: categorical values are hashed to a deterministic float in
+       ``[0, 1)``, NaNs are replaced by 0, and values are clipped to ``[-1e6, 1e6]``;
+    4. the tables are assembled into a :class:`energnn.graph.Graph` through
+       :meth:`HyperEdgeSet.from_dict` and :meth:`Graph.from_dict`.
+
+    The graph is always built on a numpy backend, because graph shapes vary from one input to
+    the next and building directly in jax would trigger one XLA compilation per new shape. If
+    ``backend`` is set, the finished graph is converted to it with :meth:`Graph.to_backend`.
+
+    :cvar elements_converter_dict: Mapping from hyper-edge class name to its
+        :class:`ElementsConverter`. Must be defined by subclasses.
+    :cvar backend: Optional target backend for the returned graph. If ``None``, the graph is
+        returned on a :class:`NumpyBackend`.
+    """
+
+    elements_converter_dict: dict[str, ElementsConverter]
+    backend: Backend | None = None
+
+    def get_structure(self) -> GraphStructure:
+        """Return the :class:`GraphStructure` describing the graphs produced by this converter.
+
+        Useful for building an EnerGNN model without having to convert an actual input first.
+        """
+        return GraphStructure(hyper_edge_sets={k: c.get_structure() for k, c in self.elements_converter_dict.items()})
+
+    def __call__(self, *args, **kwargs) -> Graph:
+        """Convert an input object into a :class:`energnn.graph.Graph`.
+
+        All arguments are forwarded verbatim to each :class:`ElementsConverter`.
+
+        :return: A graph on a numpy backend, or on ``self.backend`` if it is set.
+        """
+        # Build dict of tables
+        tables = {}
+        for k, element_converter in self.elements_converter_dict.items():
+            tables[k] = element_converter(*args, **kwargs)
+
+        # First, convert str addresses into unique integers.
+        df_port_dict = {k: tables[k][0] for k in tables.keys()}
+        df_port_int_dict, n_addresses = _str_to_int(df_port_dict)
+
+        # Then, convert features into floats.
+        df_feature_dict = {k: tables[k][1] for k in tables.keys()}
+        df_feature_float_dict = _any_to_float(df_feature_dict)
+
+        # Convert tables into an energnn.graph.Graph.
+        tables = {k: (df_port_int_dict[k], df_feature_float_dict[k]) for k in tables.keys()}
+        graph = _tables_to_graph(backend=self.backend, tables=tables, n_addresses=n_addresses)
+
+        return graph
+
+
+def _str_to_int(df_port_dict: dict[str, pd.DataFrame | None]) -> tuple[dict[str, pd.DataFrame | None], int]:
+    """Convert addresses into unique consecutive integers.
+
+    Addresses are enumerated in sorted order so that the mapping only depends on the set of
+    addresses, not on hash randomization or on the order of the tables.
+
+    :param df_port_dict: Mapping from hyper-edge class name to its address table (or ``None``).
+    :return: The translated tables and the total number of distinct addresses.
+    """
+
+    # 1. Gather the set of all addresses.
+    all_addresses = set()
+    for df in df_port_dict.values():
+        if df is not None:
+            all_addresses.update(df.values.reshape(-1).tolist())
+
+    # 2. Create a deterministic mapping from addresses to integers.
+    str_to_int_dict = {address: i for i, address in enumerate(sorted(all_addresses))}
+
+    # 3. Apply the mapping to each DataFrame.
+    out_dict = {}
+    for k, df in df_port_dict.items():
+        if df is not None:
+            out_dict[k] = df.map(lambda x: str_to_int_dict[x])
+        else:
+            out_dict[k] = None
+
+    return out_dict, len(str_to_int_dict)
+
+
+def _any_to_float(
+    feature_tables: dict[str, pd.DataFrame | None],
+    min_val: float = -1e6,
+    max_val: float = 1e6,
+) -> dict[str, pd.DataFrame | None]:
+    """Convert feature tables to bounded float tables, without mutating the inputs.
+
+    Categorical (string/object) columns are mapped value-wise to a float in ``[0, 1)`` by
+    seeding a PRNG with the value, so that a given category always gets the same float, across
+    columns and across runs. NaNs are replaced by 0, and ±inf and out-of-range values are
+    clipped to ``[min_val, max_val]``.
+
+    :param feature_tables: Mapping from hyper-edge class name to its feature table (or ``None``).
+    :param min_val: Lower bound applied to the output values.
+    :param max_val: Upper bound applied to the output values.
+    :return: New float tables, in the same layout as the input.
+    """
+
+    out_dict = {}
+    for k, df in feature_tables.items():
+        if df is not None:
+            df = df.copy()
+
+            # Convert categorical features into floats.
+            for col in df.columns:
+                if df[col].dtype.kind in {"U", "S", "O"}:
+                    df[col] = np.float64([random.Random(x).random() for x in df[col]])
+
+            df = df.astype(float)
+            df = df.replace([-np.inf, np.inf], [min_val, max_val])
+            out_dict[k] = df.fillna(0).clip(min_val, max_val)
+        else:
+            out_dict[k] = None
+    return out_dict
+
+
+def _tables_to_graph(
+    *,
+    backend: Backend | None = None,
+    tables: dict[str, tuple[pd.DataFrame | None, pd.DataFrame | None]],
+    n_addresses: int,
+) -> Graph:
+    """Assemble translated tables into a :class:`energnn.graph.Graph`.
+
+    The graph is built on a numpy backend (variable shapes are free there) and converted to
+    ``backend`` at the very end, if one is given.
+
+    :param backend: Optional target backend for the returned graph.
+    :param tables: Mapping from hyper-edge class name to its ``(address table, feature table)``
+        pair, as produced by :func:`_str_to_int` and :func:`_any_to_float`.
+    :param n_addresses: Total number of distinct addresses in the graph.
+    :return: The assembled graph.
+    """
+
+    numpy_backend = NumpyBackend()
+
+    hyper_edge_set_dict = {}
+    for k, (df_address, df_feature) in tables.items():
+        if df_address is not None:
+            port_dict = {kk: df_address[kk].to_numpy(dtype=np.int32) for kk in df_address.columns}
+        else:
+            port_dict = None
+
+        if df_feature is not None:
+            feature_dict = {kk: df_feature[kk].to_numpy(dtype=np.float64) for kk in df_feature.columns}
+        else:
+            feature_dict = None
+
+        hyper_edge_set_dict[k] = HyperEdgeSet.from_dict(backend=numpy_backend, port_dict=port_dict, feature_dict=feature_dict)
+
+    graph = Graph.from_dict(backend=numpy_backend, hyper_edge_set_dict=hyper_edge_set_dict, n_addresses=np.array(n_addresses))
+
+    if backend is not None and not isinstance(backend, NumpyBackend):
+        graph = graph.to_backend(backend)
+    return graph

--- a/src/energnn/converter/core.py
+++ b/src/energnn/converter/core.py
@@ -90,24 +90,23 @@ def _str_to_int(df_port_dict: dict[str, pd.DataFrame | None]) -> tuple[dict[str,
     :return: The translated tables and the total number of distinct addresses.
     """
 
-    # 1. Gather the set of all addresses.
-    all_addresses = set()
-    for df in df_port_dict.values():
-        if df is not None:
-            all_addresses.update(df.values.reshape(-1).tolist())
+    # 1. Gather the sorted array of all distinct addresses. The distinct values are collected
+    #    with a hash table (fast on string data) so that only the uniques need to be sorted.
+    address_arrays = [df.values.ravel() for df in df_port_dict.values() if df is not None]
+    if not address_arrays:
+        return dict.fromkeys(df_port_dict), 0
+    all_addresses = pd.Index(np.sort(pd.unique(np.concatenate(address_arrays))))
 
-    # 2. Create a deterministic mapping from addresses to integers.
-    str_to_int_dict = {address: i for i, address in enumerate(sorted(all_addresses))}
-
-    # 3. Apply the mapping to each DataFrame.
+    # 2. Translate each table through a vectorized hash lookup against the sorted addresses.
     out_dict = {}
     for k, df in df_port_dict.items():
         if df is not None:
-            out_dict[k] = df.map(lambda x: str_to_int_dict[x])
+            indices = all_addresses.get_indexer(df.values.ravel()).reshape(df.shape)
+            out_dict[k] = pd.DataFrame(indices, columns=df.columns, index=df.index)
         else:
             out_dict[k] = None
 
-    return out_dict, len(str_to_int_dict)
+    return out_dict, len(all_addresses)
 
 
 def _any_to_float(
@@ -133,10 +132,12 @@ def _any_to_float(
         if df is not None:
             df = df.copy()
 
-            # Convert categorical features into floats.
+            # Convert categorical features into floats: hash each distinct category once, then
+            # broadcast to the rows (there are usually far fewer categories than rows).
             for col in df.columns:
                 if df[col].dtype.kind in {"U", "S", "O"}:
-                    df[col] = np.float64([random.Random(x).random() for x in df[col]])
+                    hash_map = {value: random.Random(value).random() for value in df[col].dropna().unique()}
+                    df[col] = df[col].map(hash_map)
 
             df = df.astype(float)
             df = df.replace([-np.inf, np.inf], [min_val, max_val])

--- a/src/energnn/converter/element_converter.py
+++ b/src/energnn/converter/element_converter.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+from energnn.graph import HyperEdgeSetStructure
+
+
+class ElementsConverter(ABC):
+    """Abstract base class for elements converters.
+
+    An elements converter extracts, for one class of hyper-edges (e.g. ``"bus"``, ``"line"``),
+    a table of addresses and a table of features from a domain-specific object. Subclasses must
+    implement :meth:`_get_table`, which returns a single :class:`pandas.DataFrame` containing at
+    least the columns listed in ``port_list`` and ``feature_list``; :meth:`__call__` then splits
+    it into the ``(address table, feature table)`` pair consumed by :class:`Converter`.
+
+    At least one of ``port_list`` and ``feature_list`` must be provided: a hyper-edge set with
+    neither ports nor features would be empty.
+
+    :param port_list: Names of the columns of the table returned by :meth:`_get_table` that
+        contain addresses (e.g. ``["from", "to"]`` for a line). ``None`` if the hyper-edges have
+        no ports (e.g. global quantities).
+    :param feature_list: Names of the columns that contain features. ``None`` if the hyper-edges
+        carry no feature (e.g. purely structural elements).
+
+    :ivar attributes: All columns that must be fetched from the underlying data source, i.e. the
+        concatenation of ``port_list`` and ``feature_list``.
+    """
+
+    def __init__(self, port_list: list[str] | None, feature_list: list[str] | None):
+        if port_list is None and feature_list is None:
+            raise ValueError("At least one of port_list and feature_list must be provided.")
+
+        self.port_list = port_list
+        self.feature_list = feature_list
+
+        self.attributes = []
+        if self.port_list is not None:
+            self.attributes.extend([s for s in self.port_list])
+        if self.feature_list is not None:
+            self.attributes.extend(self.feature_list)
+
+    def __call__(self, *args, **kwargs) -> tuple[pd.DataFrame | None, pd.DataFrame | None]:
+        """Extract the ``(address table, feature table)`` pair for this class of hyper-edges.
+
+        All arguments are forwarded verbatim to :meth:`_get_table`.
+
+        :return: The address table (columns ``port_list``, or ``None``) and the feature table
+            (columns ``feature_list``, or ``None``); both share the same row order, one row per
+            hyper-edge.
+        """
+        df = self._get_table(*args, **kwargs)
+
+        if self.port_list is not None:
+            df_port = df[self.port_list]
+        else:
+            df_port = None
+
+        if self.feature_list is not None:
+            df_feature = df[self.feature_list]
+        else:
+            df_feature = None
+
+        return df_port, df_feature
+
+    @abstractmethod
+    def _get_table(self, *args, **kwargs) -> pd.DataFrame:
+        """Return a :class:`pandas.DataFrame` containing addresses and features.
+
+        The DataFrame must have one row per hyper-edge and contain at least the columns listed
+        in ``port_list`` and ``feature_list``.
+        """
+        raise NotImplementedError
+
+    def get_structure(self) -> HyperEdgeSetStructure:
+        """Get the edge structure of the element, useful for building an EnerGNN model."""
+        return HyperEdgeSetStructure(port_list=self.port_list, feature_list=self.feature_list)

--- a/src/energnn/problem/example/__init__.py
+++ b/src/energnn/problem/example/__init__.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from .linear_system import (
+    LinearSystemContextConverter,
+    LinearSystemOracleConverter,
     LinearSystemProblem,
     LinearSystemProblemBatch,
     LinearSystemProblemGenerator,
@@ -12,6 +14,8 @@ from .linear_system import (
 )
 
 __all__ = [
+    "LinearSystemContextConverter",
+    "LinearSystemOracleConverter",
     "LinearSystemProblemGenerator",
     "LinearSystemProblemLoader",
     "LinearSystemProblem",

--- a/src/energnn/problem/example/linear_system.py
+++ b/src/energnn/problem/example/linear_system.py
@@ -9,23 +9,62 @@ from copy import deepcopy
 
 import jax.numpy as jnp
 import numpy as np
+import pandas as pd
 from omegaconf import DictConfig
 
-from energnn.graph import GraphStructure, HyperEdgeSetStructure
-from energnn.graph import Graph, GraphShape, HyperEdgeSet, JaxBackend, NumpyBackend, collate_graphs
+from energnn.converter import Converter, ElementsConverter
+from energnn.graph import Graph, GraphShape, GraphStructure, JaxBackend, NumpyBackend, collate_graphs
 from ..batch import ProblemBatch
 from ..loader import ProblemLoader
 from ..problem import Problem
 
-LINEAR_SYSTEM_CONTEXT_STRUCTURE = GraphStructure(
-    hyper_edge_sets={
-        "line": HyperEdgeSetStructure(port_list=["from", "to"], feature_list=["susceptance"]),
-        "bus": HyperEdgeSetStructure(port_list=["id"], feature_list=["active_power_injection"]),
-    }
-)
-LINEAR_SYSTEM_DECISION_STRUCTURE = GraphStructure(
-    hyper_edge_sets={"bus": HyperEdgeSetStructure(port_list=None, feature_list=["phase_angle"])}
-)
+
+class _LineElementsConverter(ElementsConverter):
+    """Extracts one hyper-edge per line from the strictly upper-triangular part of ``B``."""
+
+    def _get_table(self, *, B: np.ndarray, P: np.ndarray) -> pd.DataFrame:
+        rows, cols = np.nonzero(np.triu(B, k=1))
+        return pd.DataFrame({"from": rows, "to": cols, "susceptance": -B[rows, cols]})
+
+
+class _BusElementsConverter(ElementsConverter):
+    """Extracts one hyper-edge per bus, with its active power injection."""
+
+    def _get_table(self, *, B: np.ndarray, P: np.ndarray) -> pd.DataFrame:
+        return pd.DataFrame({"id": np.arange(P.shape[0]), "active_power_injection": P})
+
+
+class _OracleBusElementsConverter(ElementsConverter):
+    """Extracts one hyper-edge per bus, carrying the solution phase angle."""
+
+    def _get_table(self, *, theta: np.ndarray) -> pd.DataFrame:
+        return pd.DataFrame({"phase_angle": theta})
+
+
+class LinearSystemContextConverter(Converter):
+    """Converts a DC linear system ``(B, P)`` into a context :class:`energnn.graph.Graph`."""
+
+    def __init__(self):
+        self.elements_converter_dict = {
+            "line": _LineElementsConverter(port_list=["from", "to"], feature_list=["susceptance"]),
+            "bus": _BusElementsConverter(port_list=["id"], feature_list=["active_power_injection"]),
+        }
+
+
+class LinearSystemOracleConverter(Converter):
+    """Converts the solution vector ``theta`` into an oracle :class:`energnn.graph.Graph`.
+
+    Oracles only carry features: their hyper-edges have no ports, hence no address registry.
+    """
+
+    def __init__(self):
+        self.elements_converter_dict = {
+            "bus": _OracleBusElementsConverter(port_list=None, feature_list=["phase_angle"]),
+        }
+
+
+LINEAR_SYSTEM_CONTEXT_STRUCTURE = LinearSystemContextConverter().get_structure()
+LINEAR_SYSTEM_DECISION_STRUCTURE = LinearSystemOracleConverter().get_structure()
 
 
 class LinearSystemProblemBatch(ProblemBatch):
@@ -180,35 +219,22 @@ class LinearSystemProblemGenerator:
         self.seed = seed
         self.n_max = n_max
 
+        self.context_converter = LinearSystemContextConverter()
+        self.oracle_converter = LinearSystemOracleConverter()
+
         np.random.seed(seed)
 
     def generate_problem(self, backend: JaxBackend | NumpyBackend | None = None) -> LinearSystemProblem:
-        # Graphs are built with a numpy backend: their shapes vary from one problem to the next,
-        # and building them directly in jax would trigger one XLA compilation per new shape.
+        # The converters build graphs on a numpy backend: their shapes vary from one problem to
+        # the next, and building them directly in jax would trigger one XLA compilation per new shape.
         if backend is None:
             backend = JaxBackend()
         n = np.random.randint(2, self.n_max + 1)
         m = np.random.randint(n - 1, n * (n - 1) // 2 + 1)
         B, P, theta = _generate_sparse_linear_system(n, m)
 
-        # Context
-        # Use line for off-diagonal terms
-        rows, cols = np.nonzero(np.triu(B, k=1))
-        numpy_backend = NumpyBackend()
-        line = HyperEdgeSet.from_dict(
-            backend=numpy_backend, port_dict={"from": rows, "to": cols}, feature_dict={"susceptance": -B[rows, cols]}
-        )
-        bus_context = HyperEdgeSet.from_dict(
-            backend=numpy_backend, port_dict={"id": np.arange(n)}, feature_dict={"active_power_injection": P}
-        )
-        context = Graph.from_dict(
-            backend=numpy_backend, hyper_edge_set_dict={"line": line, "bus": bus_context}, n_addresses=np.array(n)
-        )
-
-        # Oracle
-        # Use bus for the solution (phase angles)
-        bus_oracle = HyperEdgeSet.from_dict(backend=numpy_backend, port_dict=None, feature_dict={"phase_angle": theta})
-        oracle = Graph.from_dict(backend=numpy_backend, hyper_edge_set_dict={"bus": bus_oracle}, n_addresses=np.array(n))
+        context = self.context_converter(B=B, P=P)
+        oracle = self.oracle_converter(theta=theta)
 
         if isinstance(backend, NumpyBackend):
             return LinearSystemProblem(context=context, oracle=oracle)
@@ -234,8 +260,9 @@ class LinearSystemProblemGenerator:
             },
             addresses=np.array(self.n_max),
         )
+        # Oracles carry no ports, hence an empty address registry.
         max_oracle_shape = GraphShape(
-            backend=numpy_backend, hyper_edge_sets={"bus": np.array(self.n_max)}, addresses=np.array(self.n_max)
+            backend=numpy_backend, hyper_edge_sets={"bus": np.array(self.n_max)}, addresses=np.array(0)
         )
 
         # Padding and collating are done in numpy (variable shapes are free there); the padded

--- a/tests/converter/__init__.py
+++ b/tests/converter/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0

--- a/tests/converter/test_core.py
+++ b/tests/converter/test_core.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+import jax.numpy as jnp
+import numpy as np
+import pandas as pd
+import pytest
+
+from energnn.converter import Converter, ElementsConverter
+from energnn.converter.core import _any_to_float, _str_to_int
+from energnn.graph import GraphShape, collate_graphs
+from energnn.graph.backend import JaxBackend, NumpyBackend
+
+
+class _LineConverter(ElementsConverter):
+    def _get_table(self, data):
+        return data["line"]
+
+
+class _BusConverter(ElementsConverter):
+    def _get_table(self, data):
+        return data["bus"]
+
+
+class DummyConverter(Converter):
+    __test__ = False
+
+    def __init__(self, backend=None):
+        self.backend = backend
+        self.elements_converter_dict = {
+            "line": _LineConverter(port_list=["from", "to"], feature_list=["susceptance", "status"]),
+            "bus": _BusConverter(port_list=["id"], feature_list=["active_power"]),
+        }
+
+
+def make_data(n_bus: int = 3) -> dict:
+    """A small network whose buses are shared between the line and bus tables."""
+    bus_ids = [f"bus_{i}" for i in range(n_bus)]
+    return {
+        "line": pd.DataFrame(
+            {
+                "from": bus_ids[:-1],
+                "to": bus_ids[1:],
+                "susceptance": np.linspace(1.0, 2.0, n_bus - 1),
+                "status": ["open", "closed"] * ((n_bus - 1) // 2) + ["open"] * ((n_bus - 1) % 2),
+            }
+        ),
+        "bus": pd.DataFrame({"id": bus_ids, "active_power": np.linspace(-1.0, 1.0, n_bus)}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end conversion
+# ---------------------------------------------------------------------------
+
+
+def test_address_mapping_consistency():
+    """A given address must receive the same integer in every hyper-edge set."""
+    graph = DummyConverter()(make_data())
+
+    bus_ports = graph.hyper_edge_sets["bus"].port_dict["id"]
+    line_from = graph.hyper_edge_sets["line"].port_dict["from"]
+    line_to = graph.hyper_edge_sets["line"].port_dict["to"]
+
+    # bus_i rows are in table order, so bus_ports[i] is the integer assigned to "bus_i".
+    address_of = {f"bus_{i}": bus_ports[i] for i in range(3)}
+    assert line_from.tolist() == [address_of["bus_0"], address_of["bus_1"]]
+    assert line_to.tolist() == [address_of["bus_1"], address_of["bus_2"]]
+
+
+def test_addresses_cover_consecutive_integers():
+    graph = DummyConverter()(make_data(n_bus=5))
+
+    all_ports = np.concatenate(
+        [np.asarray(v) for hes in graph.hyper_edge_sets.values() if hes.port_dict for v in hes.port_dict.values()]
+    )
+    assert set(all_ports.astype(int).tolist()) == set(range(5))
+    assert int(graph.true_shape.addresses) == 5
+
+
+def test_determinism_across_instances():
+    data = make_data()
+    graph_1 = DummyConverter()(data)
+    graph_2 = DummyConverter()(data)
+
+    for key in graph_1.hyper_edge_sets:
+        hes_1, hes_2 = graph_1.hyper_edge_sets[key], graph_2.hyper_edge_sets[key]
+        if hes_1.port_dict is not None:
+            for port in hes_1.port_dict:
+                assert np.array_equal(hes_1.port_dict[port], hes_2.port_dict[port])
+        assert np.array_equal(hes_1.feature_array, hes_2.feature_array)
+        assert hes_1.feature_names == hes_2.feature_names
+
+
+def test_get_structure():
+    structure = DummyConverter().get_structure()
+
+    assert set(structure.hyper_edge_sets.keys()) == {"line", "bus"}
+    assert structure.hyper_edge_sets["line"].port_list == ["from", "to"]
+    assert structure.hyper_edge_sets["line"].feature_list == ["susceptance", "status"]
+    assert structure.hyper_edge_sets["bus"].port_list == ["id"]
+
+
+def test_input_not_mutated():
+    data = make_data()
+    original_status = data["line"]["status"].copy()
+    DummyConverter()(data)
+
+    assert data["line"]["status"].dtype == object
+    assert data["line"]["status"].equals(original_status)
+
+
+# ---------------------------------------------------------------------------
+# Backends
+# ---------------------------------------------------------------------------
+
+
+def test_default_backend_is_numpy():
+    graph = DummyConverter()(make_data())
+    assert graph._backend == NumpyBackend()
+    assert isinstance(graph.hyper_edge_sets["bus"].feature_array, np.ndarray)
+
+
+@pytest.mark.parametrize("backend", [NumpyBackend(), JaxBackend()], ids=["numpy", "jax"])
+def test_target_backend(backend):
+    graph = DummyConverter(backend=backend)(make_data())
+    assert graph._backend == backend
+    if isinstance(backend, JaxBackend):
+        assert isinstance(graph.hyper_edge_sets["bus"].feature_array, jnp.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# Shape conventions: pad and collate
+# ---------------------------------------------------------------------------
+
+
+def test_pad_and_collate():
+    """Graphs of different sizes must pad to a common shape and collate into a batch."""
+    graphs = [DummyConverter()(make_data(n_bus=n)) for n in (3, 5)]
+
+    numpy_backend = NumpyBackend()
+    max_shape = GraphShape(
+        backend=numpy_backend,
+        hyper_edge_sets={"line": np.array(4), "bus": np.array(5)},
+        addresses=np.array(5),
+    )
+    for graph in graphs:
+        graph.pad(target_shape=max_shape)
+    batch = collate_graphs(graphs)
+
+    assert batch.hyper_edge_sets["bus"].feature_array.shape[:2] == (2, 5)
+    assert batch.hyper_edge_sets["line"].port_dict["from"].shape == (2, 4)
+    assert batch.non_fictitious_addresses.shape == (2, 5)
+
+
+# ---------------------------------------------------------------------------
+# _str_to_int
+# ---------------------------------------------------------------------------
+
+
+def test_str_to_int_deterministic_sorted_mapping():
+    df = pd.DataFrame({"from": ["c", "a"], "to": ["b", "c"]})
+    out, n_addresses = _str_to_int({"line": df})
+
+    assert n_addresses == 3
+    # sorted() order: a -> 0, b -> 1, c -> 2
+    assert out["line"]["from"].tolist() == [2, 0]
+    assert out["line"]["to"].tolist() == [1, 2]
+
+
+def test_str_to_int_integer_addresses_identity():
+    df = pd.DataFrame({"id": [0, 1, 2]})
+    out, n_addresses = _str_to_int({"bus": df})
+
+    assert n_addresses == 3
+    assert out["bus"]["id"].tolist() == [0, 1, 2]
+
+
+def test_str_to_int_none_table_passthrough():
+    out, n_addresses = _str_to_int({"bus": pd.DataFrame({"id": ["x"]}), "global": None})
+
+    assert out["global"] is None
+    assert n_addresses == 1
+
+
+# ---------------------------------------------------------------------------
+# _any_to_float
+# ---------------------------------------------------------------------------
+
+
+def test_any_to_float_nan_and_inf():
+    df = pd.DataFrame({"a": [np.nan, 1.0, np.inf, -np.inf, 1e12]})
+    out = _any_to_float({"k": df})["k"]
+
+    assert out["a"].tolist() == [0.0, 1.0, 1e6, -1e6, 1e6]
+
+
+def test_any_to_float_categorical_deterministic():
+    df = pd.DataFrame({"c1": ["open", "closed"], "c2": ["closed", "open"]})
+    out = _any_to_float({"k": df})["k"]
+
+    # Every value lands in [0, 1), and a given category gets the same float in both columns.
+    assert ((out >= 0) & (out < 1)).all().all()
+    assert out["c1"][0] == out["c2"][1]
+    assert out["c1"][1] == out["c2"][0]
+    assert out["c1"][0] != out["c1"][1]
+
+    # And the same float across two separate calls.
+    out_2 = _any_to_float({"k": pd.DataFrame({"c1": ["open"]})})["k"]
+    assert out_2["c1"][0] == out["c1"][0]
+
+
+def test_any_to_float_does_not_mutate_input():
+    df = pd.DataFrame({"c": ["open", "closed"], "x": [np.nan, 1.0]})
+    _any_to_float({"k": df})
+
+    assert df["c"].dtype == object
+    assert np.isnan(df["x"][0])
+
+
+def test_any_to_float_none_table_passthrough():
+    out = _any_to_float({"k": None})
+    assert out["k"] is None

--- a/tests/converter/test_element_converter.py
+++ b/tests/converter/test_element_converter.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+import pandas as pd
+import pytest
+
+from energnn.converter import ElementsConverter
+
+
+class StubElementsConverter(ElementsConverter):
+    """Returns a fixed table, regardless of the input."""
+
+    def __init__(self, table: pd.DataFrame, **kwargs):
+        super().__init__(**kwargs)
+        self.table = table
+
+    def _get_table(self, *args, **kwargs) -> pd.DataFrame:
+        return self.table
+
+
+@pytest.fixture
+def table() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "from": ["bus_a", "bus_b"],
+            "to": ["bus_b", "bus_c"],
+            "susceptance": [1.5, 2.5],
+            "status": ["open", "closed"],
+        }
+    )
+
+
+def test_both_none_raises(table):
+    with pytest.raises(ValueError):
+        StubElementsConverter(table, port_list=None, feature_list=None)
+
+
+def test_call_splits_ports_and_features(table):
+    converter = StubElementsConverter(table, port_list=["from", "to"], feature_list=["susceptance", "status"])
+    df_port, df_feature = converter()
+
+    assert list(df_port.columns) == ["from", "to"]
+    assert list(df_feature.columns) == ["susceptance", "status"]
+    assert len(df_port) == len(df_feature) == 2
+    assert df_port["from"].tolist() == ["bus_a", "bus_b"]
+    assert df_feature["susceptance"].tolist() == [1.5, 2.5]
+
+
+def test_call_ports_only(table):
+    converter = StubElementsConverter(table, port_list=["from", "to"], feature_list=None)
+    df_port, df_feature = converter()
+
+    assert df_feature is None
+    assert list(df_port.columns) == ["from", "to"]
+
+
+def test_call_features_only(table):
+    converter = StubElementsConverter(table, port_list=None, feature_list=["susceptance"])
+    df_port, df_feature = converter()
+
+    assert df_port is None
+    assert list(df_feature.columns) == ["susceptance"]
+
+
+def test_attributes_concatenates_ports_and_features(table):
+    converter = StubElementsConverter(table, port_list=["from", "to"], feature_list=["susceptance"])
+    assert converter.attributes == ["from", "to", "susceptance"]
+
+
+def test_get_structure_round_trip(table):
+    converter = StubElementsConverter(table, port_list=["from", "to"], feature_list=["susceptance"])
+    structure = converter.get_structure()
+
+    assert structure.port_list == ["from", "to"]
+    assert structure.feature_list == ["susceptance"]
+
+    structure_no_ports = StubElementsConverter(table, port_list=None, feature_list=["susceptance"]).get_structure()
+    assert structure_no_ports.port_list is None
+    assert structure_no_ports.feature_list == ["susceptance"]

--- a/tests/problem/test_linear_system.py
+++ b/tests/problem/test_linear_system.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+import numpy as np
+
+from energnn.problem.example import LinearSystemContextConverter, LinearSystemOracleConverter
+from energnn.problem.example.linear_system import (
+    LINEAR_SYSTEM_CONTEXT_STRUCTURE,
+    LINEAR_SYSTEM_DECISION_STRUCTURE,
+    _generate_sparse_linear_system,
+)
+
+
+def test_context_converter_matches_system():
+    np.random.seed(0)
+    B, P, theta = _generate_sparse_linear_system(8, 12)
+    n = P.shape[0]
+
+    graph = LinearSystemContextConverter()(B=B, P=P)
+
+    # Bus addresses are the integers 0..n-1, in table order.
+    bus = graph.hyper_edge_sets["bus"]
+    assert bus.port_dict["id"].astype(int).tolist() == list(range(n))
+    assert np.allclose(bus.feature_array.ravel(), P)
+    assert int(graph.true_shape.addresses) == n
+
+    # Line ports point to valid bus addresses and carry the off-diagonal susceptances.
+    line = graph.hyper_edge_sets["line"]
+    rows, cols = np.nonzero(np.triu(B, k=1))
+    assert line.port_dict["from"].astype(int).tolist() == rows.tolist()
+    assert line.port_dict["to"].astype(int).tolist() == cols.tolist()
+    assert np.allclose(line.feature_array.ravel(), -B[rows, cols])
+
+
+def test_oracle_converter_carries_only_features():
+    np.random.seed(0)
+    _, _, theta = _generate_sparse_linear_system(8, 12)
+
+    graph = LinearSystemOracleConverter()(theta=theta)
+
+    bus = graph.hyper_edge_sets["bus"]
+    assert bus.port_dict is None
+    assert np.allclose(bus.feature_array.ravel(), theta)
+    # Oracles carry no ports, hence an empty address registry.
+    assert int(graph.true_shape.addresses) == 0
+
+
+def test_structures_derived_from_converters():
+    assert LINEAR_SYSTEM_CONTEXT_STRUCTURE == LinearSystemContextConverter().get_structure()
+    assert LINEAR_SYSTEM_DECISION_STRUCTURE == LinearSystemOracleConverter().get_structure()
+
+    context_sets = LINEAR_SYSTEM_CONTEXT_STRUCTURE.hyper_edge_sets
+    assert context_sets["line"].port_list == ["from", "to"]
+    assert context_sets["bus"].feature_list == ["active_power_injection"]
+    assert LINEAR_SYSTEM_DECISION_STRUCTURE.hyper_edge_sets["bus"].port_list is None


### PR DESCRIPTION
## Summary

- New `energnn.converter` package with two abstract base classes:
  - `Converter`: turns a domain-specific object (e.g. a `pypowsybl.network.Network`) into an `energnn.graph.Graph` — maps string addresses to consecutive integers (deterministic sorted order), casts features to bounded floats (categorical values hashed to a stable float in [0, 1), NaN filled, ±inf clipped), and assembles graphs through `HyperEdgeSet.from_dict`/`Graph.from_dict` on a numpy backend, with an optional target backend conversion.
  - `ElementsConverter`: extracts, for one hyper-edge class, a table of addresses and features from the input object; subclasses only implement `_get_table`.
- The LinearSystem example now builds its graphs through `LinearSystemContextConverter` and `LinearSystemOracleConverter`, which serve as the canonical example of the API. The context/decision structures are derived from `converter.get_structure()` instead of being duplicated by hand.
- Oracles carry only features: they now have an empty address registry (`n_addresses=0`) instead of an artificial one.
- 25 new tests covering the port/feature split, the core conversion invariants (consistent integer address mapping across hyper-edge sets, determinism, input non-mutation, backend handling, pad/collate compatibility) and the LinearSystem converters.
- API reference page and top-level `energnn.converter` export.

## Test plan

- [x] Full suite: 274 tests pass (249 existing + 25 new), including the trainer integration tests that run a complete training on the LinearSystem loader
- [x] CI flake8 command passes with 0 issues
- [x] Sphinx build with `-W` passes from a clean state, including the new reference page
- [x] Equivalence check: converter-built context graphs are identical (ports, features, names, masks, shapes) to the previous manual construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)