### PR TITLE
Compile the backward pass and optimizer update into a single jitted call

### DIFF
--- a/src/energnn/trainer/trainer.py
+++ b/src/energnn/trainer/trainer.py
@@ -49,11 +49,6 @@ def _cast_cotangent_to_primal_dtype(cotangent_pytree, primal_pytree):
     return jax.tree.map(_cast_leaf, cotangent_pytree, primal_pytree)
 
 
-def _update_params_fn(optimizer: nnx.Optimizer, model: GNN, gradient: nnx.State) -> None:
-    """JIT-compatible function that applies the optimizer update."""
-    optimizer.update(model, gradient)
-
-
 def _setup_ckpt_mngr(checkpoint_manager: CheckpointManager, optim_mode: Literal["minimize", "maximize"]):
     checkpoint_manager._options.best_fn = lambda x: x["score"]
     if optim_mode == "minimize":
@@ -88,6 +83,10 @@ class Trainer:
     :type model: GNN
     :param gradient_transformation: Optax gradient transformation.
     :type gradient_transformation: optax.GradientTransformation
+    :param profile: If true, synchronize the device after each stage of the training step and log
+        per-stage timings. Synchronizations prevent asynchronous dispatch, so this slows training
+        down and should only be enabled to investigate performance.
+    :type profile: bool
     """
 
     def __init__(
@@ -95,21 +94,29 @@ class Trainer:
         *,
         model: GNN,
         gradient_transformation: GradientTransformation,
+        profile: bool = False,
     ):
         self.model: GNN = model
         self.optimizer = nnx.Optimizer(self.model, gradient_transformation, wrt=nnx.Param)
         self.train_step: int = 0
         self.best_score: float | None = None
+        self.profile = profile
 
         # Cache JIT-compiled wrappers to avoid NNX re-tracing overhead each step.
         # `get_info` is static because downstream code branches on its concrete value.
-        self._jit_apply = nnx.jit(self._apply_forward_vjp, static_argnames=("get_info",))
+        self._jit_forward_vjp = nnx.jit(self._forward_vjp, static_argnames=("get_info",))
+        # The vjp residuals are dead after the backward: donating them lets XLA reuse
+        # their buffers during the backward pass instead of allocating new ones.
+        self._jit_backward_update = nnx.jit(self._backward_update, donate_argnums=(2,))
         self._jit_eval_forward = nnx.jit(self._eval_forward)
-        self._jit_update_params = nnx.jit(_update_params_fn)
 
     @staticmethod
-    def _apply_forward_vjp(graphdef, params, rest, jax_context, get_info):
-        """Forward pass + VJP setup, designed to be JIT-compiled once and reused."""
+    def _forward_vjp(graphdef, params, rest, jax_context, get_info):
+        """Forward pass + VJP setup, designed to be JIT-compiled once and reused.
+
+        The returned ``vjp_fn`` is a pytree (residual arrays + a stable treedef), so it can be
+        passed to the compiled `_backward_update` without triggering a re-trace.
+        """
 
         def f_forward(p, r):
             model = nnx.merge(graphdef, p, r)
@@ -119,6 +126,25 @@ class Trainer:
 
         (jax_decision, rest_updated), vjp_fn = jax.vjp(f_forward, params, rest)
         return jax_decision, rest_updated, vjp_fn
+
+    @staticmethod
+    def _backward_update(optimizer: nnx.Optimizer, model: GNN, vjp_fn, jax_cotangent, jax_decision, rest_updated):
+        """Backward pass, optimizer update and non-param state update in a single compiled call.
+
+        Calling ``vjp_fn`` here instead of eagerly lets XLA compile and fuse the whole backward.
+        The zero cotangent on ``rest_updated`` is a compile-time constant, and the cotangent
+        w.r.t. the non-param state is discarded: XLA prunes the corresponding computations.
+        """
+        cotangent = _cast_cotangent_to_primal_dtype(jax_cotangent, jax_decision)
+        (grads_params, _) = vjp_fn((cotangent, jax.tree.map(jnp.zeros_like, rest_updated)))
+        optimizer.update(model, grads_params)
+        nnx.update(model, rest_updated)
+
+    def _log_stage(self, name: str, value, t_start: float) -> None:
+        """In profile mode, wait for `value` and log the elapsed time of a training-step stage."""
+        if self.profile:
+            jax.block_until_ready(value)
+            logger.info(f"[training_step {self.train_step}] {name}: {(time.perf_counter() - t_start) * 1000:.3f} ms")
 
     @staticmethod
     def _eval_forward(model, context):
@@ -341,56 +367,27 @@ class Trainer:
         """
         with TaskLogger(logger, f"Training step {self.train_step}"):
 
-            t_start = time.perf_counter()
             self.model.train()  # Set model to train mode
-            logger.info(f"[training_step {self.train_step}] model.train(): {(time.perf_counter() - t_start) * 1000:.3f} ms")
 
             infos = {}
             t_start = time.perf_counter()
             jax_context, infos["1_context"] = problem_batch.get_context(get_info=get_info, step=self.train_step)
-            jax.block_until_ready(jax_context)
-            logger.info(f"[training_step {self.train_step}] get_context: {(time.perf_counter() - t_start) * 1000:.3f} ms")
+            self._log_stage("get_context", jax_context, t_start)
 
             t_start = time.perf_counter()
             graphdef, params, rest = nnx.split(self.model, nnx.Param, ...)
-            logger.info(f"[training_step {self.train_step}] nnx.split: {(time.perf_counter() - t_start) * 1000:.3f} ms")
-
-            t_start = time.perf_counter()
-            jax_decision, rest_updated, vjp_fn = self._jit_apply(graphdef, params, rest, jax_context, get_info)
-            jax.block_until_ready(jax_decision)
-            logger.info(f"[training_step {self.train_step}] forward: {(time.perf_counter() - t_start) * 1000:.3f} ms")
-
-            t_start = time.perf_counter()
-            nnx.update(self.model, rest_updated)
-            logger.info(f"[training_step {self.train_step}] nnx.update: {(time.perf_counter() - t_start) * 1000:.3f} ms")
+            jax_decision, rest_updated, vjp_fn = self._jit_forward_vjp(graphdef, params, rest, jax_context, get_info)
+            self._log_stage("forward", jax_decision, t_start)
 
             t_start = time.perf_counter()
             jax_gradient, infos["3_gradient"] = problem_batch.get_gradient(
                 decision=jax_decision, get_info=get_info, step=self.train_step
             )
-            jax.block_until_ready(jax_gradient)
-            logger.info(f"[training_step {self.train_step}] get_gradient: {(time.perf_counter() - t_start) * 1000:.3f} ms")
+            self._log_stage("get_gradient", jax_gradient, t_start)
 
             t_start = time.perf_counter()
-            jax_cotangent = _cast_cotangent_to_primal_dtype(jax_gradient, jax_decision)
-            jax.block_until_ready(jax_cotangent)
-            logger.info(f"[training_step {self.train_step}] cast_cotangent: {(time.perf_counter() - t_start) * 1000:.3f} ms")
-
-            # Backward pass
-            t_start = time.perf_counter()
-            rest_cotangent = jax.tree.map(jnp.zeros_like, rest_updated)
-            jax.block_until_ready(rest_cotangent)
-            logger.info(f"[training_step {self.train_step}] rest_cotangent: {(time.perf_counter() - t_start) * 1000:.3f} ms")
-
-            t_start = time.perf_counter()
-            (grads_params, _) = vjp_fn((jax_cotangent, rest_cotangent))
-            jax.block_until_ready(grads_params)
-            logger.info(f"[training_step {self.train_step}] vjp_fn: {(time.perf_counter() - t_start) * 1000:.3f} ms")
-
-            t_start = time.perf_counter()
-            self._jit_update_params(self.optimizer, self.model, grads_params)
-            jax.block_until_ready(nnx.state(self.model))
-            logger.info(f"[training_step {self.train_step}] update_params: {(time.perf_counter() - t_start) * 1000:.3f} ms")
+            self._jit_backward_update(self.optimizer, self.model, vjp_fn, jax_gradient, jax_decision, rest_updated)
+            self._log_stage("backward_update", nnx.state(self.model), t_start)
 
             infos["4_update"] = {}
 

--- a/tests/trainer/unit/test_simple_trainer.py
+++ b/tests/trainer/unit/test_simple_trainer.py
@@ -275,12 +275,12 @@ class TestJitCaching:
         return create_tiny_model(loader.context_structure)
 
     @pytest.mark.parametrize("get_info", [True, False])
-    def test_apply_forward_vjp_roundtrip(self, model: GNN, batch: ProblemBatch, get_info: bool) -> None:
-        """_apply_forward_vjp returns a vjp_fn whose gradient tree matches params, for both get_info branches."""
+    def test_forward_vjp_roundtrip(self, model: GNN, batch: ProblemBatch, get_info: bool) -> None:
+        """_forward_vjp returns a vjp_fn whose gradient tree matches params, for both get_info branches."""
         jax_context, _ = batch.get_context(get_info=get_info, step=0)
         graphdef, params, rest = nnx.split(model, nnx.Param, ...)
 
-        decision, rest_updated, vjp_fn = Trainer._apply_forward_vjp(graphdef, params, rest, jax_context, get_info)
+        decision, rest_updated, vjp_fn = Trainer._forward_vjp(graphdef, params, rest, jax_context, get_info)
         (grads, _) = vjp_fn((jax.tree.map(jnp.zeros_like, decision), jax.tree.map(jnp.zeros_like, rest_updated)))
         assert jax.tree.structure(grads) == jax.tree.structure(params)
 
@@ -296,18 +296,51 @@ class TestJitCaching:
         assert all(jnp.all(jnp.isfinite(x)) for x in after)
         assert any(not jnp.allclose(b, a) for b, a in zip(before, after))
 
-    def test_apply_forward_vjp_traced_once_across_steps(self, model: GNN, batch: ProblemBatch) -> None:
-        """_apply_forward_vjp's Python body runs exactly once over repeated training steps."""
-        trace_count = [0]
-        original = Trainer._apply_forward_vjp
+    def test_forward_and_backward_traced_once_across_steps(self, model: GNN, batch: ProblemBatch) -> None:
+        """The Python bodies of _forward and _backward_update each run exactly once over repeated steps."""
+        counts = {"forward": 0, "backward": 0}
+        original_forward = Trainer._forward_vjp
+        original_backward = Trainer._backward_update
 
-        def counting(*args, **kwargs):
-            trace_count[0] += 1
-            return original(*args, **kwargs)
+        def counting_forward(*args, **kwargs):
+            counts["forward"] += 1
+            return original_forward(*args, **kwargs)
 
-        with mock.patch.object(Trainer, "_apply_forward_vjp", staticmethod(counting)):
+        def counting_backward(*args, **kwargs):
+            counts["backward"] += 1
+            return original_backward(*args, **kwargs)
+
+        with (
+            mock.patch.object(Trainer, "_forward_vjp", staticmethod(counting_forward)),
+            mock.patch.object(Trainer, "_backward_update", staticmethod(counting_backward)),
+        ):
             trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-3))
             for _ in range(5):
                 trainer.training_step(batch, get_info=False)
 
-        assert trace_count[0] == 1
+        assert counts == {"forward": 1, "backward": 1}
+
+    def test_normalizer_updated_exactly_once_per_training_step(self, loader: LinearSystemProblemLoader) -> None:
+        """The forward and the backward recomputation must not both commit normalizer state updates."""
+        from energnn.model.ready_to_use import ReadyRecurrentEquivariantGNN
+
+        model = ReadyRecurrentEquivariantGNN(
+            in_structure=loader.context_structure,
+            out_structure=loader.decision_structure,
+            n_breakpoints=4,
+            latent_dimension=4,
+            hidden_sizes=[4],
+            n_steps=2,
+        )
+        trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-3))
+        batch = next(iter(loader))
+        for _ in range(3):
+            trainer.training_step(batch, get_info=False)
+
+        checked = 0
+        for _, module in nnx.iter_graph(model):
+            if hasattr(module, "train_steps") and hasattr(module, "updates"):
+                assert int(module.train_steps[...][0]) == 3
+                assert int(module.updates[...][0]) == 3
+                checked += 1
+        assert checked > 0


### PR DESCRIPTION
## Motivation

Per-stage profiling of `Trainer.training_step` (steady state, normalizer settled) showed that the backward pass dominated the step time: the `vjp_fn` returned by the jitted forward was called eagerly, executing the backward op-by-op without XLA fusion, preceded by eager cotangent casting and zero-cotangent allocation, and interleaved with 8 unconditional `block_until_ready` synchronizations used only for timing logs.

## Changes

- **Compiled backward + update.** The `vjp_fn` returned by a jitted function is a pytree whose treedef is stable across calls, so it can be passed into a second jitted function without re-tracing. `_backward_update` now compiles the cotangent cast, the backward, the optimizer update and the non-param state update into a single dispatch. The vjp residuals are donated (`donate_argnums`): they are dead after the backward, so XLA can reuse their buffers.
- **Differentiation restricted to params in effect.** The cotangents w.r.t. the non-param state are still requested (the vjp structure is unchanged) but discarded inside the compiled call, where XLA prunes the dead computations, instead of being materialized eagerly.
- **Opt-in profiling.** Per-stage synchronizations and timing logs are moved behind a new `Trainer(profile=...)` flag. The default mode dispatches the whole training step asynchronously.

## Benchmarks

RTX A1000 laptop GPU, LinearSystem example, steady state, medians over repeated runs with controlled GPU temperature (A/B/A/B protocol with cooldowns for the big config):

| Config (n_max / batch / latent / msg steps) | before | after | Δ time | Δ peak mem |
|---|---|---|---|---|
| 16 / 8 / 32 / 5 | 36.0 ms | 14.2 ms | **−61%** | +49 MiB (absolute, workspace) |
| 64 / 32 / 128 / 10 | 304 ms | 239 ms | **−21%** | ≈ 0 |
| 64 / 64 / 256 / 20 | ~1720 ms | ~1620 ms | **−6%** | **−6%** |

The gain shrinks as the workload grows because the eager backward's dispatch overhead amortizes over larger kernels; the big config is compute-bound.

## Correctness

- Final parameters after 5 SGD steps match the previous implementation within GPU run-to-run nondeterminism (6e-5 vs 1.9e-4 of noise between two identical runs); integer state (normalizer update counters) is bitwise identical.
- A first version of this change made the forward and the backward both commit normalizer state updates (nnx.jit propagates state mutations that the `jax.vjp` barrier used to discard). This was caught by the equivalence check and is now guarded by a dedicated regression test, `test_normalizer_updated_exactly_once_per_training_step`.
- Full test suite: 275 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)