### PR TITLE
Add graph visualization: plot_graph and plot_graph_interactive

### DIFF
--- a/docs/tutorial_notebook.ipynb
+++ b/docs/tutorial_notebook.ipynb
@@ -56,12 +56,13 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.078100333Z",
-     "start_time": "2026-07-21T16:05:33.359958879Z"
+     "end_time": "2026-08-03T12:20:25.522929113Z",
+     "start_time": "2026-08-03T12:20:23.202825838Z"
     }
    },
    "cell_type": "code",
    "source": [
+    "\n",
     "from energnn.problem.example import LinearSystemProblemGenerator\n",
     "\n",
     "pb_generator = LinearSystemProblemGenerator(seed=7, n_max=4)\n",
@@ -89,8 +90,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.094113397Z",
-     "start_time": "2026-07-21T16:05:36.079656098Z"
+     "end_time": "2026-08-03T12:20:25.539303941Z",
+     "start_time": "2026-08-03T12:20:25.524975990Z"
     }
    },
    "cell_type": "code",
@@ -126,8 +127,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.235103214Z",
-     "start_time": "2026-07-21T16:05:36.096357308Z"
+     "end_time": "2026-08-03T12:20:25.877448512Z",
+     "start_time": "2026-08-03T12:20:25.540363077Z"
     }
    },
    "cell_type": "code",
@@ -146,13 +147,13 @@
       "          ports               features\n",
       "             id active_power_injection\n",
       "object_id                             \n",
-      "0           0.0              -0.361243\n",
-      "1           1.0               0.397479\n",
+      "0             0              -0.361243\n",
+      "1             1               0.397479\n",
       "line\n",
-      "          ports         features\n",
-      "           from   to susceptance\n",
-      "object_id                       \n",
-      "0           0.0  1.0    0.818972\n",
+      "          ports       features\n",
+      "           from to susceptance\n",
+      "object_id                     \n",
+      "0             0  1    0.818972\n",
       "\n"
      ]
     }
@@ -188,8 +189,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.249520257Z",
-     "start_time": "2026-07-21T16:05:36.236912615Z"
+     "end_time": "2026-08-03T12:20:25.890413768Z",
+     "start_time": "2026-08-03T12:20:25.879641584Z"
     }
    },
    "cell_type": "code",
@@ -220,8 +221,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.268179407Z",
-     "start_time": "2026-07-21T16:05:36.252691865Z"
+     "end_time": "2026-08-03T12:20:25.903581831Z",
+     "start_time": "2026-08-03T12:20:25.893100440Z"
     }
    },
    "cell_type": "code",
@@ -264,8 +265,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.383860521Z",
-     "start_time": "2026-07-21T16:05:36.270146027Z"
+     "end_time": "2026-08-03T12:20:26.039022791Z",
+     "start_time": "2026-08-03T12:20:25.909348891Z"
     }
    },
    "cell_type": "code",
@@ -301,8 +302,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.401784995Z",
-     "start_time": "2026-07-21T16:05:36.385358994Z"
+     "end_time": "2026-08-03T12:20:26.052310511Z",
+     "start_time": "2026-08-03T12:20:26.041246146Z"
     }
    },
    "cell_type": "code",
@@ -341,8 +342,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:36.443299795Z",
-     "start_time": "2026-07-21T16:05:36.405111071Z"
+     "end_time": "2026-08-03T12:20:26.111954568Z",
+     "start_time": "2026-08-03T12:20:26.060428151Z"
     }
    },
    "cell_type": "code",
@@ -406,8 +407,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:37.817329690Z",
-     "start_time": "2026-07-21T16:05:36.445586844Z"
+     "end_time": "2026-08-03T12:20:26.484423249Z",
+     "start_time": "2026-08-03T12:20:26.115394985Z"
     }
    },
    "cell_type": "code",
@@ -451,8 +452,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:38.062081735Z",
-     "start_time": "2026-07-21T16:05:37.842356523Z"
+     "end_time": "2026-08-03T12:20:26.777373062Z",
+     "start_time": "2026-08-03T12:20:26.491850569Z"
     }
    },
    "cell_type": "code",
@@ -470,55 +471,55 @@
       "                   ports               features\n",
       "                      id active_power_injection\n",
       "batch_id object_id                             \n",
-      "0        0           0.0              -0.153267\n",
-      "         1           1.0               0.064413\n",
-      "         2           2.0              -0.103239\n",
-      "         3           0.0               0.000000\n",
-      "         4           0.0               0.000000\n",
-      "1        0           0.0              -0.963238\n",
-      "         1           1.0               1.151337\n",
-      "         2           0.0               0.000000\n",
-      "         3           0.0               0.000000\n",
-      "         4           0.0               0.000000\n",
-      "2        0           0.0              -1.221684\n",
-      "         1           1.0              -5.470104\n",
-      "         2           2.0               3.197233\n",
-      "         3           3.0               3.825995\n",
-      "         4           0.0               0.000000\n",
+      "0        0             0              -0.153267\n",
+      "         1             1               0.064413\n",
+      "         2             2              -0.103239\n",
+      "         3             0               0.000000\n",
+      "         4             0               0.000000\n",
+      "1        0             0              -0.963238\n",
+      "         1             1               1.151337\n",
+      "         2             0               0.000000\n",
+      "         3             0               0.000000\n",
+      "         4             0               0.000000\n",
+      "2        0             0              -1.221684\n",
+      "         1             1              -5.470104\n",
+      "         2             2               3.197233\n",
+      "         3             3               3.825995\n",
+      "         4             0               0.000000\n",
       "line\n",
-      "                   ports         features\n",
-      "                    from   to susceptance\n",
-      "batch_id object_id                       \n",
-      "0        0           0.0  1.0    1.248804\n",
-      "         1           0.0  2.0    0.998507\n",
-      "         2           1.0  2.0    1.133648\n",
-      "         3           0.0  0.0    0.000000\n",
-      "         4           0.0  0.0    0.000000\n",
-      "         5           0.0  0.0    0.000000\n",
-      "         6           0.0  0.0    0.000000\n",
-      "         7           0.0  0.0    0.000000\n",
-      "         8           0.0  0.0    0.000000\n",
-      "         9           0.0  0.0    0.000000\n",
-      "1        0           0.0  1.0    1.185360\n",
-      "         1           0.0  0.0    0.000000\n",
-      "         2           0.0  0.0    0.000000\n",
-      "         3           0.0  0.0    0.000000\n",
-      "         4           0.0  0.0    0.000000\n",
-      "         5           0.0  0.0    0.000000\n",
-      "         6           0.0  0.0    0.000000\n",
-      "         7           0.0  0.0    0.000000\n",
-      "         8           0.0  0.0    0.000000\n",
-      "         9           0.0  0.0    0.000000\n",
-      "2        0           0.0  3.0    0.631458\n",
-      "         1           1.0  2.0    1.227435\n",
-      "         2           1.0  3.0    0.873341\n",
-      "         3           2.0  3.0    1.040881\n",
-      "         4           0.0  0.0    0.000000\n",
-      "         5           0.0  0.0    0.000000\n",
-      "         6           0.0  0.0    0.000000\n",
-      "         7           0.0  0.0    0.000000\n",
-      "         8           0.0  0.0    0.000000\n",
-      "         9           0.0  0.0    0.000000\n",
+      "                   ports       features\n",
+      "                    from to susceptance\n",
+      "batch_id object_id                     \n",
+      "0        0             0  1    1.248804\n",
+      "         1             0  2    0.998507\n",
+      "         2             1  2    1.133648\n",
+      "         3             0  0    0.000000\n",
+      "         4             0  0    0.000000\n",
+      "         5             0  0    0.000000\n",
+      "         6             0  0    0.000000\n",
+      "         7             0  0    0.000000\n",
+      "         8             0  0    0.000000\n",
+      "         9             0  0    0.000000\n",
+      "1        0             0  1    1.185360\n",
+      "         1             0  0    0.000000\n",
+      "         2             0  0    0.000000\n",
+      "         3             0  0    0.000000\n",
+      "         4             0  0    0.000000\n",
+      "         5             0  0    0.000000\n",
+      "         6             0  0    0.000000\n",
+      "         7             0  0    0.000000\n",
+      "         8             0  0    0.000000\n",
+      "         9             0  0    0.000000\n",
+      "2        0             0  3    0.631458\n",
+      "         1             1  2    1.227435\n",
+      "         2             1  3    0.873341\n",
+      "         3             2  3    1.040881\n",
+      "         4             0  0    0.000000\n",
+      "         5             0  0    0.000000\n",
+      "         6             0  0    0.000000\n",
+      "         7             0  0    0.000000\n",
+      "         8             0  0    0.000000\n",
+      "         9             0  0    0.000000\n",
       "\n"
      ]
     }
@@ -539,8 +540,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:38.224827327Z",
-     "start_time": "2026-07-21T16:05:38.063517762Z"
+     "end_time": "2026-08-03T12:20:26.949564738Z",
+     "start_time": "2026-08-03T12:20:26.784901894Z"
     }
    },
    "cell_type": "code",
@@ -603,8 +604,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:38.236048229Z",
-     "start_time": "2026-07-21T16:05:38.227203996Z"
+     "end_time": "2026-08-03T12:20:26.964111512Z",
+     "start_time": "2026-08-03T12:20:26.956273569Z"
     }
    },
    "cell_type": "code",
@@ -647,8 +648,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:39.541503324Z",
-     "start_time": "2026-07-21T16:05:38.242681327Z"
+     "end_time": "2026-08-03T12:20:27.507307889Z",
+     "start_time": "2026-08-03T12:20:26.972976172Z"
     }
    },
    "cell_type": "code",
@@ -693,8 +694,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:40.834697732Z",
-     "start_time": "2026-07-21T16:05:39.551299703Z"
+     "end_time": "2026-08-03T12:20:29.030283229Z",
+     "start_time": "2026-08-03T12:20:27.526634793Z"
     }
    },
    "cell_type": "code",
@@ -719,8 +720,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:40.856806303Z",
-     "start_time": "2026-07-21T16:05:40.849558707Z"
+     "end_time": "2026-08-03T12:20:29.057010039Z",
+     "start_time": "2026-08-03T12:20:29.045284701Z"
     }
    },
    "cell_type": "code",
@@ -741,8 +742,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:43.776472221Z",
-     "start_time": "2026-07-21T16:05:40.858204523Z"
+     "end_time": "2026-08-03T12:20:32.145876594Z",
+     "start_time": "2026-08-03T12:20:29.060030650Z"
     }
    },
    "cell_type": "code",
@@ -762,9 +763,9 @@
       "             features\n",
       "          phase_angle\n",
       "object_id            \n",
-      "0           -1.241964\n",
-      "1            0.971998\n",
-      "2            0.320928\n",
+      "0            0.450049\n",
+      "1           -0.789633\n",
+      "2           -0.137394\n",
       "\n"
      ]
     }
@@ -780,8 +781,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:47.468460140Z",
-     "start_time": "2026-07-21T16:05:43.789973546Z"
+     "end_time": "2026-08-03T12:20:35.330651712Z",
+     "start_time": "2026-08-03T12:20:32.162782946Z"
     }
    },
    "cell_type": "code",
@@ -801,26 +802,26 @@
       "                      features\n",
       "                   phase_angle\n",
       "batch_id object_id            \n",
-      "0        0            3.879246\n",
-      "         1           -4.336865\n",
-      "         2            0.713661\n",
+      "0        0           -4.552955\n",
+      "         1            4.906845\n",
+      "         2           -0.427487\n",
       "         3           -0.000000\n",
       "         4           -0.000000\n",
-      "1        0           -1.430068\n",
-      "         1            0.131218\n",
-      "         2            1.134047\n",
+      "1        0            0.504705\n",
+      "         1           -0.862865\n",
+      "         2           -0.848117\n",
       "         3           -0.000000\n",
       "         4           -0.000000\n",
-      "2        0           -1.850926\n",
-      "         1           -1.140654\n",
-      "         2            0.897193\n",
-      "         3            2.514515\n",
-      "         4            0.000000\n",
-      "3        0           -7.895837\n",
-      "         1            1.512679\n",
-      "         2            1.366065\n",
-      "         3            6.228894\n",
-      "         4           -1.681872\n",
+      "2        0            1.593576\n",
+      "         1            0.251861\n",
+      "         2           -0.994634\n",
+      "         3           -2.644902\n",
+      "         4           -0.000000\n",
+      "3        0            8.727511\n",
+      "         1           -2.082402\n",
+      "         2           -2.001105\n",
+      "         3           -7.048380\n",
+      "         4            1.668270\n",
       "\n"
      ]
     }
@@ -853,8 +854,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:47.637888461Z",
-     "start_time": "2026-07-21T16:05:47.489173121Z"
+     "end_time": "2026-08-03T12:20:35.486091870Z",
+     "start_time": "2026-08-03T12:20:35.345808112Z"
     }
    },
    "cell_type": "code",
@@ -877,8 +878,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:05:47.645806868Z",
-     "start_time": "2026-07-21T16:05:47.639741254Z"
+     "end_time": "2026-08-03T12:20:35.496725501Z",
+     "start_time": "2026-08-03T12:20:35.488714947Z"
     }
    },
    "cell_type": "code",
@@ -893,8 +894,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-07-21T16:06:07.770592262Z",
-     "start_time": "2026-07-21T16:05:47.648072732Z"
+     "end_time": "2026-08-03T12:20:46.529627146Z",
+     "start_time": "2026-08-03T12:20:35.499047806Z"
     }
    },
    "cell_type": "code",
@@ -912,27 +913,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Validation: 100%|██████████| 2/2 [00:01<00:00,  1.09batch/s, score=1.0137e+01]\n",
-      "Epoch 1/10: 100%|██████████| 16/16 [00:04<00:00,  3.37batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 20.99batch/s, score=2.6364e+00]\n",
-      "Epoch 2/10: 100%|██████████| 16/16 [00:01<00:00, 11.68batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 22.49batch/s, score=2.5761e+00]\n",
-      "Epoch 3/10: 100%|██████████| 16/16 [00:01<00:00, 11.77batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 21.03batch/s, score=2.5172e+00]\n",
-      "Epoch 4/10: 100%|██████████| 16/16 [00:01<00:00, 11.49batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 19.23batch/s, score=2.4606e+00]\n",
-      "Epoch 5/10: 100%|██████████| 16/16 [00:01<00:00, 11.75batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 20.72batch/s, score=2.4061e+00]\n",
-      "Epoch 6/10: 100%|██████████| 16/16 [00:01<00:00, 10.61batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 21.11batch/s, score=2.3535e+00]\n",
-      "Epoch 7/10: 100%|██████████| 16/16 [00:01<00:00, 11.57batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 19.30batch/s, score=2.3027e+00]\n",
-      "Epoch 8/10: 100%|██████████| 16/16 [00:01<00:00, 11.45batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 20.10batch/s, score=2.2536e+00]\n",
-      "Epoch 9/10: 100%|██████████| 16/16 [00:01<00:00, 11.66batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 20.86batch/s, score=2.2057e+00]\n",
-      "Epoch 10/10: 100%|██████████| 16/16 [00:01<00:00, 11.67batch/s]\n",
-      "Validation: 100%|██████████| 2/2 [00:00<00:00, 20.42batch/s, score=2.1590e+00]\n"
+      "Validation: 100%|██████████| 2/2 [00:01<00:00,  1.28batch/s, score=3.2412e+00]\n",
+      "Epoch 1/10:   0%|          | 0/16 [00:00<?, ?batch/s]/home/dononbal/PycharmProjects/energnn/.venv/lib/python3.12/site-packages/jax/_src/interpreters/mlir.py:1274: UserWarning: Some donated buffers were not usable: float32[4,3,1], float32[4,3,1], float32[4,3,1], float32[4,3,1], int32[4,3], float32[4,3,4], float32[4,3], int32[4,3], int32[4,3], float32[4,3,4], float32[4,3], float32[5,4,3,4], int32[4,3,1], float32[4,3,1].\n",
+      "See an explanation at https://docs.jax.dev/en/latest/faq.html#buffer-donation.\n",
+      "  warnings.warn(\"Some donated buffers were not usable:\"\n",
+      "Epoch 1/10: 100%|██████████| 16/16 [00:03<00:00,  4.43batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 94.23batch/s, score=9.2184e-01]\n",
+      "Epoch 2/10: 100%|██████████| 16/16 [00:00<00:00, 25.91batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 121.76batch/s, score=9.0958e-01]\n",
+      "Epoch 3/10: 100%|██████████| 16/16 [00:00<00:00, 26.06batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 112.48batch/s, score=8.9713e-01]\n",
+      "Epoch 4/10: 100%|██████████| 16/16 [00:00<00:00, 26.06batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 123.72batch/s, score=8.8640e-01]\n",
+      "Epoch 5/10: 100%|██████████| 16/16 [00:00<00:00, 25.85batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 99.84batch/s, score=8.7758e-01]\n",
+      "Epoch 6/10: 100%|██████████| 16/16 [00:00<00:00, 25.95batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 81.77batch/s, score=8.7031e-01]\n",
+      "Epoch 7/10: 100%|██████████| 16/16 [00:00<00:00, 21.59batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 117.12batch/s, score=8.6439e-01]\n",
+      "Epoch 8/10: 100%|██████████| 16/16 [00:00<00:00, 26.54batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 121.46batch/s, score=8.5956e-01]\n",
+      "Epoch 9/10: 100%|██████████| 16/16 [00:00<00:00, 26.51batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 123.53batch/s, score=8.5496e-01]\n",
+      "Epoch 10/10: 100%|██████████| 16/16 [00:00<00:00, 26.44batch/s]\n",
+      "Validation: 100%|██████████| 2/2 [00:00<00:00, 124.33batch/s, score=8.5154e-01]\n"
      ]
     }
    ],
@@ -947,6 +951,145 @@
     "Notice that the approach is not limited to linear system and can be used for a much broader set of applications!"
    ],
    "id": "6adb93eb2ba67ded"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Graph Visualization\n",
+    "\n",
+    "`plot_graph` renders a static matplotlib figure, while `plot_graph_interactive` builds a\n",
+    "self-contained HTML/SVG figure: hover any object to see its port addresses and feature\n",
+    "values, scroll to zoom, drag to pan, and double-click to reset the view.\n",
+    "Both only accept single graphs, so batches must first go through `separate_graphs`."
+   ]
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-08-03T12:22:04.820446310Z",
+     "start_time": "2026-08-03T12:22:04.758812548Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from energnn.graph import plot_graph, plot_graph_interactive, separate_graphs\n",
+    "\n",
+    "graph = separate_graphs(context)[2]\n",
+    "plot_graph(graph)\n"
+   ],
+   "id": "f0e433b3ed0fb592",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: >"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 700x700 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqUAAAEcCAYAAAD+9c0SAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATCpJREFUeJzt3Xl4HOWZ9/tvVXVXq7W0vMvWZlvGu1lMyGRhyCQOwwBJSCAJJEAChAFMzpmTCXNm3pk3mZkrk4VcZ953Nt4MW9ghhATCFpYECBD2ADYOlnfLsjZb3tWSWl3VXVXnj2q1bLCNF0ndLf0+16UL4+62S3Kr+6fnuZ/7NmprZwSIiIiIiBSQWegLEBERERFRKBURERGRglMoFREREZGCUygVERERkYJTKBURERGRglMoFREREZGCUygVERERkYJTKBURERGRglMoFREREZGCUygVERERkYJTKBURERGRglMoFREREZGCUygVERERkYJTKBURERGRglMoFREREZGCUygVGfeMYb6fiIjI0YsU+gJEpNAC6q54AtOuOOQ9fLefzjs+M4rXJCIi441CqYhg2hWYdmWhL0NERMYxbd+LiIiISMFppVRERETGjWg0Sn1dLXbMxnVcOjq7yGQyhb4sQaFURERExoHq6gSnLj2ZBfPnYtt2/vdd12Xd+o2sWLmKnp5kwa7ve9/7HolEgm9/+9vHdPtYoFAqIiIiY1pt7QzO++zZxGKx991m2zYnnbiY+fNO4LHHn6Jr2/YCXKGAakpFRERkDKuuThwykO4vFotx3ufOobo6MUpXNnwikbGxxqhQKiIiImPWqUtP/sBAOigWi3Hq0pOH7e+++uqrefnll1m/fgOvvPIql19+Rf62j3zkIzz77HNs2LCRW2/9KRUVB3ZAOdzt9fX1dHZ2ceGFF/Hyy6/w1ltvA7BkyYn88pe/ZPXqZl5++RUuvvji/GOWLDmRxx9/nHXr1vPuu6u588678rf9z//5HVaufId169bz0ksvceaZZ+ZvO++8z/PMM8+yZs1annjiSU477bT8beeff37+83vrrbf567/+6+P6eo2NaC0ix8V3+4/rdhGRYhSNRlkwf+5RPWbB/Lm8/Mrrw3L4qaOjgwsvvJCuri4+/vGPc/fd97B69Wo2btzAHXfcyY9+9EPuv/9+li1bxs0338Kjjz4CQHV19WFvH3TWWWdx7rnn4LoZpk6dys9/fj//8A//wBNPPMHcuXP52c/up62tjZdffpkf/vCHPPPMM5x33nlEo1GWLl0KwCc+8Wecf/75nH32X9Dd3U1tbR1lZWGIX7ZsGf/0T//I5ZdfQXPzas4++2zuvPNOzjjjDNLpNP/+7//BRRddyBtvvEEikWD27NnH9fVSKBUZxxKJKnr7UkfYGN8AgpG+JBGRYVNfV3vAoaYjYds29XW1bGndetx//5NPPpn/9auvvsqLL77Ixz/+MWbObKS7u5t7770XgGeeeYZXXnklf98zzzzzsLcP+vd//zeSyfBw1uWXX87rr7/B448/DsD69ev5xS8e4AtfCFczM5kMdXX1TJ8+nW3btvHGG28AkM1miMVizJs3n927d9PV1Zn/8y+//HJuvPFGVq9+F4CnnnqKa65ZzrJly3jyySfJZrPMnTuX5uZmkskkq1atOq6vl0KpyDg1WPhvWRae7x/0Pq7j8ORTz7C9ewcKpCJSauzY0QXS/OPs6LD8/eeffz7XXLOc+vp6TNMkHo/T3t5GNuvR0dFxwH07OzvyZQY1NdMPe/vQ7w0FyIaGBpYtW8aaNWvzv2dZVj58/s3fXMd1113HU089TU9PD3fccQd33nkHr776Kv/7f/8v/u7v/pYTTpjLSy+9xPe//y+0t7dTX9/A3//9P/A3f/P/5v/MaDTK9OkzGBgY4PLLL+Pqq6/hO9/5LuvWreNf//X/49VXXz3mr5dCqcg49N7C/4lVCT7zuS9QXl6B7/u89srvWb9+LTHb5guf/wz3P/BQQVuliIgcC9dxj+1x7vFv3dfW1vEf//GfXHrpJbz66qt4nsdtt92OYRh0d2+nvr7+ffffvXsXwAfePsjfb0Ghq6uLp59+mm9+89qDXs/WrVv51re+BcCHP/wn/PznP+ftt9/i3Xff5a677uKuu+6iqqqK66//Md///g+4/PLL6Orq4o47bueee+456J/58ssv8/LLLxOJRLjsssu47bbbWbRoIUFwbIsYOugkMg69t/Df931+9+xvuP2nN/LLB+5l2Zl/QTQarhQMd+G/iMho6ejswnWPLpi6bthQ/3hVVJRjGAa7du3C932WLVvGn/3ZnwHw3HPPMX36dC6++GIsy+LTn/40p59+ev6xH3T7wTz00IOcfvrpnHvuuUQiESKRCIsXL+bkk8PX7y996UtMmTIFgGSyhyAI8H2fk08+mdNOO41oNEo6nSaVSpHNZgG46647Wb78Wk488UQAysrinHHGGcyYMYMpU6Zw9tlnU1FRQTabpbe3D8/LHtfXTKFUZJw5WOF/f38fO3Z0537dz8BAirKyeP72BfPn5kOqiEipyGQyrFu/8ages279xmE55LRx40b+67/+i1/8IjwNf9555/Hb3/4WgH379vGNb1zBlVf+JWvXruOrX72Yhx9+OP/YD7r9YLZv387FF1/MpZd+jZUr3+Gdd1bxwx/+iKqqKgDOOOMMnnnmWTZs2Mjtt9/B97//fZqbm6mqquJHP7qe1aubWbnyHaZPr+Gf/umfgLCW9frrf8S//uv/Ys2atbz++utceeVfYhgmpmly5ZV/yZtvvsW6deu5/PLLufrqq495lRTAqK2doUIxkXFk9qyZnPe5cw55e03NDM797Oe547abDvj9xx5/algK/0VERlN1dYKvXvTFI2oL5TiOypUKSCulIuPM4Qr/y8rK+MxnP89vnv71+x83TIX/IiKjqacnyWO/fhrHcQ57P8dxeOzxpxRIC0gHnUTGmUMV/luWxflfvIjXX3+Frs6O990+WPj/yanhy8bqHo9drjZaRKT4dXVt4/4HHuLUpSezYP7cA9pEua7LuvUbWbFylQJpgSmUiowzg4X/7+3dd+5nPk/b1lbWNL/7vsfsX/j/sckRFlRZAOxyfFYnPZqTHmuSHn3HV+MuIjJienqSPP/CS7z8yuu5/qVRXDdDR2fXsNSQyvFTKBUZZwYL/086cXH+9+rqG1iwcDE7dnRzwtz5ADzx60fYtXMHMFT4bwLP73DZ6URYnLCYEjP55FSTT04Nt/a3pjyaezyakz4b+jzcg7c/FREpmEwmo/r4IqWDTiLjxCTb4NQJFs/uyA5b4X9NzGBxwmJxtcWiKovyiJG/zQsCNvb6NOdWUrf0+yijiojIoSiUiowDH51kcfmsGEEA/+PdFMns0ESnwwXTwcL/rm3bP/DvMIGZFSZLEhaLExZzK00i5lBIHfAC1uYC6uqkx/a0XnpERGSIQqnIGFZuwWUzY3x0clip8/KuDHe1ugyeT6quToxY4X/UgHlVZriSmrCYVWECQyF1rzu0itqc9OnJ6KVIRGQ8UygVGaMWVplc3RRjkm3Snw24o9Xhzb3eQe8bjUZHvPC/woJFuYC6uNpiWuzAjnSdA0MhdV3SI629fhGRcUWhVGSMiRjwxboo586IAgbNPR63bnHYW2QrkVNsg0UJiyXVFosSFlX71aP6QcDmfp81SY/VPR6b+3284rp8EZHDev31N/jnf/5nfvObpwt9KSVDp+9FxpC6uMG1TTEayi2yfsADHQ7PdGc5mjx3cYPNzAqTf9+QHtHVyl1uwO93Zfn9riwGUB83WVIdbvfPr7KYWxl+fL4WXD9gXa4WtTnp0TGghCoiMtYolIqMAQZwVk2EC+ttIqZBe8rjxhaHzmMIbzMrTBZUWTSUm2zsG5099ABoH/BpH/B5ansWy4ATKsNDU4sSFk0VJidNiHDShPAlK5kJ8r1Rm5Meu9XEX0QOy4Aj+vH8SO8nI0GhVKTETYwaXNUUY3HCAgKe3ObyUGeG7DG+rran/DCUxkcvlL6XF8D6Xp/1vT4PdWaIW7CgysofmqqNm3xscoSP5Q5wdaeH6lHXJD1SBy+dFZFxK6Duiicw7YpD3sN3++m84zPD+rfOnz+Pb3/728yaNYu3336b6677NtFolDfe+AMLFy4gmQwPkn7ve98jkUjw7W9/G9u2uf76H3PWWWcRiUTo6uriuuu+zapVq4b12oqRQqlICfvwRItvzIpRHjHY7frc0uKwrvf4gmR7Knx8Q7n5AfccPQMerNznsXJfmDYnRo3coSmTxdUWNWUmNWUmy6ZFCYKA1tRQSN3Y61Nk5bQiUgCmXYFpV47q3/nVr17MpZdeSmdnJz/+8fXccMMNXHfddYd9zJe//GUWLVrE6ad/nGQySVNTE+l0epSuuLAUSkVKUNyCrzXanD4lnKT02u4sd291hmWFsH2g+ELpe+3NBLyyO8sru8P/ry0bauK/sMpidkX48dkZkPEDNvT5uUlTHm0pNfEXkdFx9913s3nzJgB+8IMfsGrVH5kxo/awj8lkslRWVjB37lxWrFhBS0vLaFxqUVAoFSkx8ypNls+JMdk2GfAC7mx1eH3P8O1Xdwz4QEBDvHhD6Xt1pQO60lme2ZHFBJoqwwNTixIW8yqHeqUC9GfDJv6rc1v93Y6WUUVkZHR2duR/vWvXLtLpNNns4dvtPfTQg9TUTOPHP/4xM2bU8swzv+Vf/uX77N27Z6Qvt+AUSkVKhGXABXVRPptr9bQu6XHzFoc9w3zIx/WhOx1QU2Yy2TZK7hCRD2zq89nU5/NoVwbbhPm5etQlCZOGcovTJkU4bVL48rfbHVpFXZP0SGYLe/0iMnbU1dXnfz158mTKysrYvj2ckBePx/M1pdOm1ZBODwDgeR433HADN9xwA1OmTOG///u/ue666/jHf/zu6H8Co0yhVKQE1JYZXNMUY1aFhRcE/LLD4entR9fq6Wi0D/jUlJk0lJvsdkv71JDrw7s9Hu/2hJ9HIhI28R/skTrZNvnEVJNPTA1LIdpTHquTYU3q+l4PV3v9InKMLr30Un7729/Q2dnJd77zXV577TW2bdtGR0cHX/7yl/nJT37Cxz72MZYtW8aTTz4BwOmnn86+fftYt24dqVSKdNrB88bHT8sKpSJF7sxpEb7SYBM1DToHfG7cnKZ9hPt0dqR8TpsIDXGTd/aVdih9r2QWXt/j5UsepsWM3CqqxcKERUN5+HHO9Ch+ELCxb+jQVEuf6lFF5Mg98MDP+clP/ptZs2axYsUK/uqv/m8A/uZvruP666/nr/7q/+G5557j0UcfJRoNI9mUKVP54Q9/RG1tLel0mpdeeol/+7d/K+SnMWo00UmkSFVHDa6abXNidfhC9ZvtGX7Z4Y7KSfLTJlr81QllvLEny39vdkb+LywSJtBYPlSDOq/KJGoOTZpKewFre738dn9XWi+fIqWi4ZoXDnv63nf7aL/5k6N3QfI+WikVKUIfmmhx5awYFRGDva7PrVscmpOjt0aXbwtVQoedhoMPtKZ8WlM+T2zPEB1s4l8dhtTZFSZLJ0RYmmvi35PxaU76rO4J61GLbZSriAzx3f7jul1GnlZKRYpImQmXNNr5+sY/7MlyZ6tD/yjvoJvAzR8qJ2LA1W+n1Oczp9zarx41EfZH3V/XwNBW/7pej4GxVfkgUsI00akUaKVUpEicUGmyvCnG1JhJ2gu4a6vDq7sLk2p8wtZQTRXh9KStKVVSAqQ8eGuvx1t7w3+XybaRbz01OGmqNm7y5zVhPeqW/qGQuqnPP+YpWyJyvI70m0/fpIWklVKRAjOB8+uifG5GFMMwWN/rcXOLU/BWTFfOCldsb2lxeGX3+Dj5ebzq40a+HnVhwsLerx7V9QPW94YBdXWPT8eAr7c/EZH9aKVUpIBqYgbXzokxu8LCDwJ+2e7y1PZMUZzwPmCy0+4CX0yJ6BgI6BjI8pvuLJYBcyrM/KSpORUmJ1ZHwoNrDdCXDcJV1NyhqV0l1g9WRGS4KZSKFMinpka4uNHGNg26BnxubnFoLaJt8rb8YSfjA+4pB+MFsKHPZ0Ofz8NdGcpMWJBbRV2csKiLm3xkUoSP5Jr473AObOI/2nXEIiKFplAqMsoSEbhydoxTcie4n+nO8ED76LR6OhqDJ/Aby60CX8nYkPbhnX1evu9rddRgUcLM90idFjOZNs3kU9OiQEBrv8+apEdz0md9r1d0zw8RkeGmUCoyik6ZELZ6SkQNkpmAm1scVieLc0ms34N9GZ8JUZOqCPSqrHRY9WQCXtvt8VruMNv0MoMluUNTixIWsyrCj3NnQNYfauK/OumxtV9N/EVk7FEoFRkFtgkXN9i5VTB4a2+WO1od+oo86HWkfCZUm9THTdb2KgaNpO3pgO3pLM/uyGICsyqGVlHnVpkszB2e+hKQyuaa+Cc9Vvd4dDtaRhWR0qfT9yIjrKkibPVUU2bieAH3trn8fleRp9Gci+qjnDvD5mdtDr/pLo1rHotsE+ZVWixOmLlVVJOwn2JojzvUeqq5xyep3lMiBff662/wz//8z5SXx7n88iv4/OfPK/QlFT2tlIqMEBM4rzbK52ujmIbBpj6Pm1ocdpbQqtYBJ/ClYFwfVue27iFDZQQWVln5SVNTYyZnTDE5Y0q4Et8xENajru7xWN/rkdYit0jBPPzwwzz88MOFvoySoFAqMgKmxQyWN8WYUxm2evpVp8vjXcXR6ulotKfCAD3exo0Wu74svLnX481cE/+psaH+qIsSFvXxsOTirFwT/819PqtzK6mb+w5dj2qbYZuyHU6AU2pPVpGjoOd6cdI7jcgw+8SUCD9YHGdOpUV32udf1qZ5tAQDKcC2tI8fBNTFTb1YFLGdTsALO7P8ZLPD/70yxT82D/BAu8vqnixeAHOrLM6vs/nuwjg3nVrOt+fG+IuaCHXvafdlGfAfp5RjqguYjHGj+Vy/8MIL+e1vn8n//+uvv8G1136Txx9/nPXrN/Dggw9RW1ubv33y5MnccMP/YcWKlbz99gq+973vYdv2yF9oEdD7jMgwqYzAt06IceXsGDHL4Hc7Mny3eYAt/aUYR0PZALalA6KmwdSYkkopCAh7zD65PcO/bnBYviLF9esGeKzLpaXPwzbhlAkRLm6M8aMl5dxwSjnXzLaZFDW4pNFmkm1ySaNNTO8OMkbZJgV/rl9wwQV885vf5KSTTiSVSvG3f/u3+dvuvPNOdu7cwcc//nHOPPPTLFq0iG9961ujf5EFoJcdkWFwUrXF9UvKOXVihGQm4N82pLlrq4tbunk0b6hfqV4uSlE2gHW9Pg91Zvje2jTfXJniPzemebY7w7a0TyJqUBU1yAYBF9SFqzEX1NlEDBRMZUyyDA54rhdiZ+Duu++ivb0dx3F4+OFfceKJJwFw8sknM3v2bL7//e+TTg+wd+9e/uu/buALXzh/9C+yAFRTKnIcbBO+0mDz6Vyrp5X7sty+xSE5hg6qtw/4fJQwlA7WMErpSnmwYp/HilwT/wkRMAyDCxts4lb47hy3DC5utHlhR5avNkZZkwxP92/q89XEX0ra4Crp/s/1Sxpt7tnqjmpt6Y4dO/O/TqUGqKysBKChoYFEoprm5jX52w3DwLLGxxAThVKRYzSr3GT5nBgzykxcP+C+NpcXdo6hNJozuFJar8NOY9K+LMStoVXSQefX2fy83SXlwedqbT5XCxk/YH1vOGVqTdJja8pHGVVKyf6rpIMuqLO5r80t0BUdqKuri127dnHqqUsLfSkFoVAqcpRM4DMzolxQF7Z6aun3uGmzM2YbmKst1Nj23pWjQXHL4KIGm5tbHJZN9VhSHeGESpMl1RGWVIf36c8GuVGoYbuqUmp3JuPP4Z7rhVgtPZh33nmHrq4u/u7v/o6f/OQn9Pf3U1dXx7x583j++ecLe3GjQKFU5ChMscNWT3OrwlZPj3S6JXuy/kjtcQNS2YCpMZMyE/W8HGMOtnI0aHAF6dFtWR7dliVmwoKqsO3U4oRFQ7nJhydF+PCk8K1klzPUempN0iv6iWUyvhzJc73QfN/nssu+zne+811efPFFKiur6Ozs5N577wXGfijVRCeRI3T65Ahfn2lTZhnscHxu2uywuYRP1h+N7ywoY16Vxb+sGRg3n/N4YJvw9Zk2lzTGDnmf+9qcQ64gJSIGixJmvon/JPvA1fS2VLjVv7rHY0OfNyYO/klpOt7nuowOhVKRD1BhwRWzYvnVoBd3ZrivbXy9cH19ZniY685Wh+fHYN3seDa7wsQ+TGWG63PEbc1q3tPEvzwytE3qBQEb+4YmTW3pP3QTf5GRMJzPdRkZCqUih7EkYXFVk82EqElfNuC2LU7+1PJ48qmpES6fFePZ7gz3FMEWlxQ/k7Bjw+Aq6rxKk8h+vXfSXsDaXC1qc9JjW1pvRSLjnWpKRQ4iasCFDTZn1YStnv7Yk+XWFpdkdny+ceqwkxwtH2hN+bSmfH69LUPUgHlVZn4ldVaFydKJEZZODN+G9rp+rhY1/O8+9Z4SGXcUSkXeoyFucu2cGHVxk4wfcH+7y3M7xveWdUeuLVSD2kLJMcoE0Jz0aU76QIYKCxYlhg5N1ZSZ/OkUkz+dEt6/ayA8NLUm6bE26emAncg4oFAqkmMA50yP8qX6KJZh0NrvcVOLo21FwhP3uxyfKTGTiVGDvVrFkuPU78Gbe738QIbJ9lA96uJqi9q4SW3c5KyaKH4Q0NIfrqAONvH39BQUGXNUUypC+IZ4dVOMBVUWQRDw+LYMj3Rl9Ma3n78+IcbSiRH+bUOaVT3jr65WRo8B1MeNfEBdUGVh71eP6voB63o9mnvCkNoxEKiJv8gYoJVSGfc+Ntnispkx4pbBLsfn5haHDX3aK3yv9gGfpRPDulKFUhlJAdA+ENA+kOXp7iyWQdi4P7fd31RhclJ1hJOqw7ewZGaoiX9z0mO3q4gqUooUSmXcKrfgspkxPjo5/DZ4eVeGe7a6ql07hDaNG5UC8QJY3+uzvtfnoc4MZSYszAXUJYlwq/+jkyP57+XutJ9v4L8m6dGvn6FESoJCqYxLC6tMrm6KMck26c8G3NHq5Gvb5OAGT+A36gS+FFjah5X7PFbm2rNNiA7Wo5osrg4PTdWUmSybFgUCWvuHJk1t7PVRSbRIcVJNqYwrEQO+VG9zzvQIYNDc43HLFkftZ46ACdzyoXIsA/7y7ZTqbaVozSgLQ+qShMXChEXZfrPOs37Ahr5wJXV1j0dbSk38RYqFQqmMG3Vxg2ubymgoN8n6AQ90uDzTndUBiaPwvUVlzKqw+O7qFO0D+spJ8TMJJ/ksqQ63++dVmpjGUEhNZQ+sR+129LwWKRRt38uYZwBn1US4sN4mYhq0pzxubHHoVKg6au0DPrMqLBrKTdoHVO4gxc8HNvf7bO73ebQrg23CvEorN2nKpLHc4rRJEU7LjRHe7Q6NQl2T9MftwAyRQlAolTFtYjRs9bQoYQEBT25zeagzg95njk37AU30FUql9Lg+rM6NNwWoipBv4L84YTElZnLGFJMzpoTT3NpTQ/1R1/d6ONrrFxkxCqUyZn14osU3ZsUojxjsdn1uaXFY16t3lOOhcaMy1vRm4Y09Hm/sCUPq1JjBklxAXZQIdwUayk3Onh428d80WI+a9GjpUz2qyHBSTamMOXELvtZoc3pupeO13Vnu3uqQ0sLecauKwP9ZWsG+jM+33hko9OWIjCgDmFlu5ltPzasyie7XxD/tBazt9fLb/V2a/iZyXLRSKmPKvEqT5XNiTLZNUtmAu7Y6vL5HaXS49GbDRuUToiYVFur/KGNaALSmfFpTPk9uzxDNNfEfnDQ1u9xk6YQISyeEb6U9GZ/mpJ+fNKVxvCJHRyulMiZYBlxQF+WzM6KAwbqkx81bHPZossuw+7t5ZSyutrh+3YDKIWRcK7fCJv6D7adqyg4sa9mWHgqoa3s9dDZQ5PC0Uiolr7bMYPmcGDPLLbwg4JcdDk9vV6unkdI24LO42qIhbiqUyriW8uDtvR5v5wZvTLKN/IGpxQmLGWUmM8pMzqyJEgQBW/Zr4r+pz9eBS5H3UCiVknbmtAhfabCJmgadAz43bk6rf+YI60jpsJPIwexxA17aleWlXVkg7I08eGhqYcKiqTL8OK8WMn7A+l6P5mQYVNtTvn6QlnFPoVRKUnXU4KrZNidWh0/hp7dneLDD1fjAUaAT+CJHpnMgoHMgy2+6s5jAnFw96pKExZxKkyXVEZZUw0VA335N/Ff3eOxS6ZGMQ6oplZLzoYkWV86KUREx2Ov63LLFYU1S28ijJWqE40azAVz9dkqrOyLHoMyE+VWDTfwt6uIH/pC30xkahbq216MvW6ALFRlFWimVklFmwqUz7XxT6z/syXJnq6MT4KMsE8D2dEBt3GRazNBYRpFjkPZhVY/Hqp7wBSwRMVhcPbSSOjVm8smpJp+cGgUCWvv93Eqqz4Y+D1c/h8sYpFAqJeGESpPlTTGmxkzSXtjq6dXdSqOF0j7gUxsPm4p3O/p3EDleyWzAa7s9Xsu9rtXEjPwq6qKExayK8OPcGeAFARt7hw5NtfYffxP/aDRKfV0tdszGdVw6OrvIZDLH/4mJHAVt30tRM4Hz66J8bkYUwzBY3+txc4vDbtVbFdR5M6J8sd7m4U6XR7r0xiUykkxgVoWZP9U/r8rEMoaa+Key+zXxT3psP4om/tXVCU5dejIL5s/Ftu3877uuy7r1G1mxchU9Pcnh/HREDkmhVIpWTczg2jkxZldY+EHAgx0Zntqe0Vi/IrB0gsVfzy3jrb1ZbtjkFPpyRMYV24R5lRaLE2ZuFdUknD8V2usOraI29/gkD9F7qrZ2Bud99mxisdgh/y7HcXj0sSfZtn0HHFEFuXGE9xN5P4VSKUqfmhrh4kYb2zToGvC5qcVha0pxtFhMtg3+7eRyutM+f/euxo2KFFJlBBZWWflJU9NiBx6a6hwID00NHpzKBuEK6Vcv+uIBgXTOnLl8atmfYxgGb7z+Kn/840oAent7uf3O+6i74glMu+KQ1+G7/XTe8ZmR+SRlXFBNqRSVRMTgytk2p+TG9j3TneGBdrV6Kja73YC0F1BTZmCb6NCFSAH1ZeHNvR5v5pr4Txls4r/fyf66uMmfT4vw9+8OsN0JOHXpyQcEUsMw+NSnz+LnP7sbx0lz2eVXsWHDOtLpAezc/Uy7AtOuLMjnKOODQqkUjaUTLK6cHaMqYpDMBNzc4rA6qUM0xap9wGdupUV93KSlX6lUpFjscgNe3JXlxV1ZDMKewksSFlUR2O4E2NEoC+bPPeAxM2rr2LVrJ319vQC0tGxi9uwm1q5tLsBnIOOVQqkUnG3CJY12rvUJvLU3yx2tjvryFbn2lEKpSLELgLaUT9t+5U91dbUHHGoCqKysoq936EBTX28vlVWJ0bpMEUChVAqsqSJs9VRTZuJ4Afe2ufx+l9JoKWjXuFGRkmTH7A++k0gBKJRKQZjAebVRPl8bxTQMNvV53NTisFON2EvG4LjRRoVSkZLiOu77fq+v78CV0cqqKrZt6xrNyxJRKJXRNy1msLwpxpzKsNXTQx0uv96mVk+lpiMXShviCqUipaSjswvXdQ/Ywt/W1cnUKVOprKzCcdI0NZ3Aq6+8VMCrlPFIoVRG1SemRPjazLDVU3fa58YWhy2qRyxJAx7sdn0m2yYTogb71CJBpCRkMhnWrd/ISScuzv9eEAQ8/7tn+MrFX8cwDP7w+quk02r3JqNLoVRGjG2GDfB3OAFRA66cHePUieFT7nc7Mtzf7qqVUIlrS4WhtD5usi+jTgkixawmZnDKBIvfdGdZsXIV8+edcEBbqE2bNrBp04b3Pc51wgEZvtt/2D//g24X+SAKpTJiLAP+45RyvvaHfr4+MwykyUzAT7c4rOpRgBkLOlI+SyeEdaVq3yVSvAYHkmR9eG13lp6eJI/9+ukjmuj01NPPAsYRNsbXRCc5dgqlMiIG2zxNsk0uabR5ZkeGqBlwR6tLUofrx4zBw046gS9SnBIR+MbsGEtzA0l+vzNDKvfzY1fXNu5/4CFOXXoyC+bPPaDG1HVd1q3fyIqVq+jpSR7sjz4EBVI5dhozKiOi3IIHP1ZJ3DIY8AK+/Fof/VpIG3NqywyuP7Gc9pTHd5vThb4cEdnPydUWfzk7RiIaDiS5dYvDHw+xSxWNRqmvq8W2o7huho7OLjKZzChfsYx3WimVYWUQjrj7Ql2UuGUAELcMvtpoc89WF0c1pGPK9nSAFwTUxU1MUAcFkSJgm/DVBptl08KBJCv2ZrntAwaSZDIZtrRuHaUrFDk47bnJsJliG3ylPorjB5xfd2Bz5gvqbEyjQBcmI8YnbA1lGgYz4voHFim02RUmP1gcZ9m0KI4XcNsWh//cpAl5UhoUSmVY/OnkCD9YXMabez0uarDzq6SD4pbBJY02MT3jxpyOlPqVihSaCXy+Nso/LSyjpsxkU5/Hd5sHNCFPSoq27+W4VFjwjVkxTpsU4d2eLNsd/32rpIMuqLO5r+39k0SktO1/2On1PSocFhlt02IG1zTFOCE3kORXnS6Pd2kgiZQehVI5ZksSFlc12UyImvRmfH66xeErB1klHTS4Wqra0rGlPRWeldRKqcjo+8SUCJc22sSscCDJTS0OLRpIIiVKoVSOWtSACxtszqoJi+j/2JPlxs0OKQ+e25HlpcNsF7k+CqRjTFtKbaFERltlBK6YFeO03ECS53dk+JkGkkiJUyiVo9IQN7l2Toy6uEnGD7i/3eW5HUMhVCNDx59kNqA3GzDJNim3yPdAFJGRsSRhcU1T2OqpNxseZlq5T994UvoUSuWImMDZ06N8uT6KaRi09nvc1OKwLa02txIedlqYsKiPm2zo0w8mIiMhasBXGmzOzO1SvbMvy21bXJJZvQ7L2KBQKh9osm1wdVOMBVUWQRDwWJfLI10ZPL0OSk77QBhKG8sVSkVGwqxyk2uaYtTGTVw/4GdtLs/v1Ml6GVsUSuWwPjbZ4rKZMeKWwS4nLKLfqNAh79GuulKREWEC50yP8qXcLtWWfo8bNzt0O1oVkLFHoVQOqtyCy2bG+Ojk8Cny0q4M9251SSuPykEMHnaq1wl8kWEzxQ5bPc3L7VI92uXySKdaPcnYpVAq77OwKtwmmmib9GcD7mh1eHOviujl0LrSPkEQ0BA3MQCt4Ygcn9MnR/j6TJsyy2Bnbpdqk3apZIxTKJW8iAFfqrc5Z3oEMGju8bhli8O+jCKGHJ7rQ7cTML3MZErMYKe2FkWOSYUFl8+K8SeTwrfn3+/McF+bdqlkfFAoFQDq4wbLm8poKDfJ+gEPdDg8053VipccsY6Uz/Qyk4a4yU5HK+siR2txwuSq2UO7VLe1OrytXSoZRxRKxzkDOKsmwoX1NhHToC0VtnrqHFAclaPTNuBzGuFhpxXqmShyxKIGfLne5i+mh62e3u3JcusWlx7tUsk4o1A6jk2Mhq2eFiUsIODJbS4PdWZQyzs5FvkT+DrsJHLEGuIG184pyw8k+Xm7y7M71OpJxieF0nHqTyZZXDEzRnnEYLfrc0uLw7peFS3JsWsfUFsokSNlAGdPj/DlehsrN5Dk5haHLg0kkXFMoXSciVvw9ZkxPp5r9fTa7ix3b3U0GlKO2y4nwPECamIGUQO08yhycJNsg2tmx1iQ26X69TaXX3VqIImIQuk4Mq/SZPmcGJNtk1Q24K6tDq/vURqV4REAHQM+cyot6uImrSmtvIu810cnhQNJBnepbtrsaAqaSI5C6ThgGXBBXZTPzogCBmuTYaunPa5+LJfh1Z4LpY3lCqUi+yvP7VJ9LLdL9cquDPe0uQxoXUAkT6F0jKstM1g+J8bMcgsvCPhFu8Nv1OpJRojGjYq834LcQJJJuV2q2zWQROSgFErHsDOnRfhKg03UNOgc8Llxc5p2tXqSETR42EnjRkXCgSRfrItybm6XqjnpcWuLw14VXIsclELpGFQdNbhqts2J1eE/79PbMzzY4ergiYw4rZSKhOriBtc2xWgotzSQROQIKZSOMadNtPjGrBgVEYO9rs8tWxzWJFXbJ6Mj5cEe12eSbZKIGCTV9FbGGQP485oIF+UGkrSnPG7UQBKRI6JQOkaUmXDpTJszpoQTQf6wJ8udrQ79KluSUdaRCkNpY7nJ6qSegDJ+TIwaXDU7xuJqDSQRORYKpWPACZUmy5tiTI2ZpL2w1dOruxUGpDDaBnxOmgAN5Qark4W+GpHR8eHcLlV5xGBPbiDJWg0kETkqCqUlzATOr4vyuRlRDMNgfW84EWS3Wj1JAXXosJOMI2UmfG2mzZ/mdqk0kETk2CmUlqiamMG1c2LMrrDwg4Bftrs8tT2Dfi6XQmvTYScZJ+ZVhq2epsRMBryAO1s1kETkeCiUlqBlUyN8tdHGNg26BnxuanHYqkblUiS2DQT4QUBtzMAAnTaWMccy4PzacCCJYRis6/W4RbtUIsdNobSEJCIGfznb5uQJ4T/bM90ZHmhXqycpLj7QORCwL+MrkMqYM6PMYHlTjFm5Xapf5Hap9FwXOX4KpSVi6QSLK2fHqIoYJDMBN7c4OtksRast5fG7HVka4wbdToCjhXwZA94/kMTJD4wQkeOnUFrkbBMuabT55NSwiP6tvVnuaHXoyxb4wkQOY+U+jx2Ozx0fruDSP/QX+nJEjksiYnBVk81JuYEkv+3O8AvtUokMO4XSItZUEbZ6qikzcbyAe9tcfr9LaVSK34Zej4sabCbZJpc02tyz1dVqqZSkU3O7VJURg32ZsNVTswaSiIwIhdIiZALn1Ub5fG0U0zDY1OdxU4vDTkc/lktpyARwfp0NwAV1Nve1uQW+IpGjEzPh0kabT+R2qd7cE+5SaSCJyMhRKC0yNTGDa5pizKkMi+gf6nD59Ta1epLSYZtwcaNN3DIAiFuGVkulpJyQa/U0LTeQ5O6tLq/s1i6VyEhTKC0ifzYlwqUzw1ZP3WmfG1sctvTrXVxKi2WEq6P702qplAIT+EJdlPNyrZ429oa7VLvU6klkVCiUFoGqCFw5K8bSieE/x+92ZLi/3cVVHpUSM3gwb3CVdJBWS6XY1cQMls+J0ZRr9fRgh8uT2qUSGVUKpQV2UrXFVbNjJKJhq6efbnFY1aOiJSlNB1slHaTVUilWn5oa4eLcQJJtaZ+bNju0aiCJyKhTKC0Q24SvNNh8elpYRL9yX5bbtzgkVbYkJepQq6SDtFoqxSYRgW/MjrE0N5Dk2e4MD3Rol0qkUIza2hkqlhlls8pNrp0TY3qZiesH3Nfm8sJOpVEpfbMrTOzcyHsDiJlhQE374cuM66M6aSkKp0ywuHLW0C7VrVsc/qhdKpGC0krpKDKBz8yIckFd2OqpJdfqqVutnmSMeG/gvKg+SiJqcH+bS5/e76UI2CZc3GDzqdwu1Yq9WW7TQBKRoqBQOkqm2GER/dxcq6dHOl0e7VIRvYxt08pMTpsY4a29Hiv3KZVKYc2uMLlWA0lEipZC6Sj408kRvjbTpswy2OGERfSbtYUp40BHyue0iVAfNxVKpWBM4HO1Ub6w30CSm1scdmiXSqSoKJSOoAoLvjErxmmTwi/zizsz3NemQx4yfrQPhE/2hnKzwFci49W03ECSE3K7VL/qdHlcu1QiRUmhdIQsSVhc3WRTHTXpywbctsVhhVaKZJxpz7XVaYgrlMro+8SUCJc22sSscCDJTS0OLdqlEilaCqXDLGrAhQ02Z9WERfR/3Jfl1i0uyay2iWT82eEEuH7A9DKDqAEZfRvIKKiMhLtUH9JAEpGSolA6jBrLwyL62rhJxg/4WZvL79TqScaxAOgY8GmqsKiNm2xVQ3IZYSdWW1ydG0jSm9ulUj2zSGlQKB0GJnD29Chfrg+L6Fv7w1ZP29JaFhJpT4WhtF6hVEZQ1AgHkpyZ26V6Z1+W27RLJVJSFEqP02Tb4OqmGAuqLIIg4LEul0e6Mnh6HRQBwpVSyB122l3gi5ExaVa5yTW5XSo3t0v1vHapREqOQulx+Nhki8tmxohbBrucsIh+Y59WgkT215ZbHW3UYScZZiZw7owoXxwcSNLvcdNmDSQRKVUKpceg3ILLZ8X4SK7V00u7Mty71SWtPCryPvkT+GoLJcNoih22epqX26V6tMvlkU61ehIpZQqlR2lhVbhNNNE26c8G3NHq8OZeFdGLHEq/B/syPhOiJokIJLWrKsfp9MkRvp4bSLIzt0u1SbtUIiVPofQIRQz4Ur3NOdPDIvrmHo9btjjsU48bkQ/UnvKZUG1SX26yJqnwIMemwoIrZsX4cG6X6ve5gSTapRIZGxRKj0B93GB5UxkN5SZZP+CBDpdnurMojoocmfaUz4nVYRN9hVI5FosTJlc3xZgQDXepfqqBJCJjjkLpYRjAWTURLqy3iZgGbamw1VPngOKoyNHQuFE5VlEDvlxv8xe5Xap3e8KBJD3apRIZcxRKD2FiNGz1tChhAQFPbHP5VWcGtbwTOXoaNyrHoiFucu2cGHW5gST3t7s8t0NFySJjlULpQfzJJIsrZsYojxjsdn1uaXFY16stR5Fj1ZUO8IOAuriJCTohLYdlAOdMj/Kl+ihWbiDJzS0OXRpIIjKmKZTuJ27B12fG+Pjk8Mvy2u4sd291SKlsSeS4eAFsS4ehdFqZwXaFCzmESbbBNbNjLMjtUv06t0ulgSQiY59Cac68SpPlc2JMtk1S2YC7tjq8vkdpVGS4tKd86uImDXGT7Wl9b8n7fXSSxeWzwoEku12fmzY7bFCrJ5FxY9yHUsuAC+qifHZGFDBYmwxbPe1x9WO5yHBqH/D5KNBYbqq3rxygPLdL9bHcLtXLuzLco4EkIuPOuA6ltWUGy+fEmFlu4QUBv2h3+I1aPYmMCB12koNZkBtIMim3S3W7BpKIjFvjNpT++bQIFzXYRE2DzgGfGzenaVerJ5ERM9gWql5toYRwIMkX66Kcm9ulak563NrisFetnkTGrXEXSidEDa6abbOkOvzUn96e4cEOF70OioysPW5AKhswNWZSZqKt2XGsLm5wbVOMhnIrN5DE0UASERlfofS0iRbfmBWjImKw1/W5ZYuj6TIio6h9wGd+lUVd3GRzv773xpv3DiRpT3ncqIEkIpIzLkJpmQmXzrQ5Y0o4EeQPe7Lc2erQr7IlkVHVkQuljeUKpWOdbUJNzGCHE+D44UCSq5piLM61enpym8tDGkgiIvsZ86H0hEqT5U0xpsZM0l7Y6unV3UqjIoWQP+ykutIxzzLgP04p59I/9DOv0uTbc8sojxjscX1u1kASETmIMRtKTeD8uiifmxHFMAzW94YTQXar1ZNIweQPO+kE/phmm3BJo80k2+SSRpsXd2aJWxpIIiKHNyZD6fSysIh+VoWFHwT8ot3l6e0ZjTYUKbAOtYUaF8L+zzYQ/veBdpcfr09rdVREDmvMhdJlUyNc3Bi2euoa8LmpxWFrSi+EIsUg7cNOx2dqzGSSbWhIxRgUy62Sxi0DgLhlcFGDzT1b3QJfmYgUuzETShMRg7+cbXPyhPBTeqY7wwPtavUkUmw6UmEobYib7HG1jzuWTIpCJhhaJR10QZ3NfW0KpSJyeCURSqPRKPV1tdgxG9dx6ejsIpPJ5G+fX2nyV3PLqIoY9GR8bmlxWZ3Um51IMWof8Fk6MTzstKpH36djxaenWrSmApZNi+RXSQfFLYNLGsPVUkcbVyJyCEUdSqurE5y69GQWzJ+LbQ/95O26LuvWb2TFylX09CTZmvLZ4/qs7w24fYtaPYkUs7aUDjuNJYmIwVVNNgbw5l6H89+zSjpIq6Ui8kGKNpTW1s7gvM+eTSwW4wsXXEhj40y2tm7h0UcexLZtTjpxMfPnncBjjz9F17bt/GBtGlc/gYsUvcET+I1qC1XyPjTR4spZMcot+N7aAS5ssN+3SjpIq6Ui8kGKMpRWVyfygRTg7bfe4N0/vsOSJScdcL9YLMZ5nzuH+x94iJ6eZCEuVUSO0o50QMYPmFFmYBngqe675JTlDjN9Ymo4kOSxLpct/QHP7cjy0q7sIR/n+iiQisghFWUoPXXpyflACtDetpWGxpkHvW8sFuPUpSfz/Asvjdblichx8IHOAZ9ZFRa1ZQbtGjFZUt47kOTurS6v7A6D6BZN6RKR41B0+2fRaJQF8+ce1WMWzJ9LNBodoSsSkeE2uIWvyU6lwwQuqIvy3QVlTI2ZbOj1+M7qgXwgFRE5XkW3UlpfV3vAoaYjYds29XW1bGndOkJXJSLDqf2AJvo6mVjsamIG186JMTs3kOTBDpcnt2kgiYgMr6ILpVbEwnGHTmhapkkk8sGXadtaKRUpFVopLR2fyg0ksU2DbWmfmzY7tGogiYiMgAKGUgN4fy3Zpk0tbNrUkv9/y4qw/OrLP/BPc92wb+nFDTYTbIPmHo/mpMcuTYwRKTr5lVKF0qKViMCVs2OckhtI8mx3hgc6XHU5EZERU8BQGlB3xROYdsUh7+G7/XTe8Rm+cvFlTJ8+nWjU5tpv/jWPPvIgXV0d+fu5bthQH2BmhcmCKouPTAo/tR2Onw+oa5KeepiKFIHeLCQzAROiJhUW+r4sMqdMCFs9JaIGyUzALVsc3tWgAxEZYQXdvjftCky78gPvd9+9dxA7TJ3puvUb8xOefrIpzeJqi8UJiyUJi2kxk2nTTD41LQoEtPb7rEl6NCd91vd6GkMqUiDtKZ/F1RYN5SbrerX8VgxsM9xtCl8v4e29WW5vdejTWSYRGQVFV1N6tBzHYcXKVfn/T2bhtd0er+0Of6qfXmawJGGxKPcxqyL8OHcGZP2AjX0+zclwJbW131fhvsgoaRsIQ2mjQmlRmF1hcm1TjJoyE8cLuLfN5feH6TkqIjLcSjqUOo7DY48/ddjG+dvTAdvTWZ7dkcUEZlWY+VXUuVUmCxMWCxMWXwJS2YC1vWFAXd3j0e1oGVVkpHRo3GhRMIHP1Ub5Qm0U0zDY1Odxc4vDDr3+icgoK4lQmnHdA7bvXddl3fqNrFi56qgmOflAS79PS7/P49sy2CbMq7RYnDBzq6gmH5oY4UMTwy/LHndoFbW5xyeZ1Yu0yHDRCfzCmxYzuKYpxgmVYaunX3W6PN6lVk8iUhglEUrvuufnNNTXYdtRXDdDR2dXvob0eLg+rE56rE56QIbKCCyssliSq0mdGjM5Y4rJGVPC+qrOAT+/irq+1yOtV26RY9Y14OMHAfVx8xC9OGQkfWJKhEsbbWKWQXfa56YWhxZNZBKRAiqJUJrNZkelMX5fFt7c6/Hm3rAedWrMYHEiDKiLEhZ1cZO6uMlZNVH8IGDzfvWom/pUjypyNDJBWF5TGzeZFjNULjNKKiPwjVmx/I7Q73ZkuL9drZ5EpPBKIpQWyk4n4IWdWV7YmcUg3GZckgi3++dXWczNfXyhDhwvYN1gPWrSo1PzvEU+UPuAT23cpKHcpNtRy6GRdmK1xdWzw1ZPvdmAn25xeGefvu4iUhwKGkp9t/+4bh9NAdCW8mlL+Ty5HSIGnFA5dGhqdoXJyRMinJxrNJ3MBPneqKuTHnvUxF/kfdpTPh+ZFB52emuvwtFIsU24qN7mzJqwFOmdfVlu2+KqTl5EiopRWzujQK9KR1pFVhrVZuUWLKgKt/oXV1vMKDvw8EZ32md1bqt/bdIjpfdfEZZOsPjruWW8tTfLDZucQl/OmDSr3GT5nBgzykxcP+BnbS7P71SrJxEpPgWd6DS89yuslAcr9nmsyG2FTYwa+YC6JGFRU2ZSU2by6WlRgiBgS2po0tSmPl9N/GVcahscN6q2UMPOBD4zI8oFdWGrp5Z+j5s2O6rdFZGiVcCV0vGlLm7kD0wtrLIos4z8bRk/YENvuJK6JumxNeWXSBQXOX43n1pOmQVXvZ3SYZthMsU2WN4UY26VRRAEPLYtwyOdavUkIsVNB51GSedAQOdAlt92h038myoHD01ZYW1qdbiqCtCfDXKjUMN61J1a2ZAxrH3AZ26lRX3cVEuiYXD65Ahfn2lTZhnsdMJWT5v69HUVkeKnldIiEDPDetRFuZD63mbiu5yh1lNrkh69KgeTMeSymTbLpkW5fYvDixprecwqLLhiVowPTwrXGn6/M8N9ba76KYtIydBKaRFwfFjV47GqJ6xHTUQMFiVMllSHQXVKzOTPppr82dTw5GxbyqM5GQbV9b2etjylpLUPjhvVZKdjtjhhcnVTjAlRk/5cq6cVavUkIiVGobQIJbMBr+/xeH1P+KZS854m/o3l4cc508Mm/hv6/LD1VI/Hln418ZfSMjhutFGh9KhFDbiwweasXKund3uy3LrFpUcnJ0WkBGn7vsSYhG/eg6NQ51WaRMyhQ1NpL2BtrhZ1TdKjK61/XilucQtuOrWC/mzAN1emCn05JaMhbnLtnBh1cZOMH3B/u8tzO1T+ICKlSyulJcYHWlM+rSmfX2/LEDVgbtVQE/9ZFSZLJ0ZYmhshuC8z2Hoq3O7fpxUUKTIDHux2fSbbJhOihp6jH8AAzpke5Uv1USzDoLXf4+YWRz+AikjJUygtcZkA1iR91iR9fkmGCgsWJYYOTdWUmZw+xeT0KeH9uwaGWk+tTXo6BCFFoS0VhtKGcpN9PaqFPJRJtsE1s2MsSFhAwK+3ufyqM4OnPCoiY4BC6RjT78Gbez3ezI1snGwP1aMurraojZvUxk3OqgnrUVv6/fwo1E19vt7cpCA6Uj5LJ4Rb0u8qlB7URydZXD4rRtwy2O363LTZYYNaPYnIGKJQOsbtdgN+vyvL73dlMYD6+NCkqQVVFidUhh/n1YLrB6zr9fKTpjoGAjXxl1ExeNjpve3QJBxhfNnMGB+dHL5cv7wrwz1b1epJRMYehdJxJADaBwLaB7I83Z3FMggb9+dWUpsqTE6qjnBSdfi06M018V+dC6m7XUVUGRntGjd6UAurwlZPk2yTVDbg9lYnvwsiIjLW6PS95JWZsDBXj7okEW7176877ecb+K9JevTrvVGGiQnc+qFyTAOufCs17tuaRQz4Ur3NOdMjgEFzj8etWxz26hCYiIxhWimVvLQPK/d5rMw13Z4QNXK9UcMWVDVlJjVlJsumRYGA1v6hSVMben30finHygc60z4zyy1mxA06B8bvk6kubnBtUxkN5SZZP+CBDodnurMqpRGRMU+hVA5pXybgld1ZXtkd/v+MMiPfemphwmJWRfjxmRmQ9cMm/oMhdaua+MtRak+FobQhbtI5MP6W4Q3grJoIF9bbREyD9pTHjS3OuA7oIjK+KJTKEduWDtiWzvLsjiwmMLtiaBTqvEoz34rqy0AqG7Bmv0NT3Y7eWOXwOvY77DQ4zWy8mBg1uKopxuJcq6cnt7k81Jkhq28bERlHFErlmPjA5n6fzf0+j3ZlsE2YV2nlJk2ZNJZbnDYxwmm5Jv673aFRqGuSPkm928p7tKfC50TjODvs9OGJFt+YFaM8YrDH9bm5xWFdr/YZRGT8USiVYeH6sDrX7xSgKkK+gf/ihMWUmMkZU0zOmBLO6O4Y8POrqOt6PRy9B497bbkT+PXjpC1U3IKvNdqcnvueeG13lru3OqTG1yKxiEieQqmMiN4svLHH443cNuzUmMGSXEBdlLCoj5vUx03+YnrYxH9Trh51ddKjpe/99ai2CTUxgx1OoAA7RiWzAb3ZgEm2SbnFmA5n8ypNls+JMdk2GfAC7mx1xl3JgojIe6kllIw6A5hZbuZbT82rMomaRv52xwtY2+vlD011DgTELbj3Tyq49A/9jMMzMOPG/5hfxqKExY/WDbB+DG5hWwZcUBflszOigMG6Xo9bWhz1ABYRQSulUgAB0JryaU35PLk9Q3T/Jv7VFrPLTU6ZEOGUCRGCIOBf1qZZNi3CJNvkkkabe7a6Wi0dozoGfBYlwhP4Yy2U1pYZXNMUY1aFhRcE/LLD4entavUkIjJIoVQKLhPA2l6ftb0+D3ZmKLfCJv6LExZRA3Y5PhfU2QBcUGfzQLvLGVMi7HHDsahjeZt3vMlPdhpjdaVnTovwlQabqGnQOeBz42YnP1pVRERCCqVSdFIevL3X4+29HrYJX59pE7fC7f24ZfCVBpsXdmb5zoIyALb0+6zObfVv6vPVRqeE5Q87jZET+NVRg6tm25yYG937m+0ZftnhatCEiMhBKJRKUQtr8OwDfu/8Opuftbk81pXh7OlRmiotmiotzquFjB+wvtejORkenGpL+doeLSGdAz5BENAQNzGgpP/tPjTR4spZMSoiBvsyPre0ODQntToqInIoCqVStGwTLmkcWiUdFLcMvpqrLX24K5OvR12SsJhTabKkOsKS6vC+/dkgf2BqdY/HLh0oKWqZALqdgOllJlNiBjtLcOhCmQmXzrTz7c/e3JPljlaHfpWZiIgclkKpFK2DrZIOuqDO5r42lwDY2Oezsc/nka4MZSbMrxps4m9RFzf5k0kR/mRS+FTf5Qxt9a9JevRlR/ETkiPSkfKZXmbSEDfZ6ZRWkjuh0mR5U4ypMZO0F3D3VpdXdutJJiJyJBRKpSgdapV0UNwyDnoSP+3Dqh6PVT1hmElEDBZXD62kTomZfHKqySenhqtYW1ODo1B9NvR5uNpdLbi2AZ/TCA87rdhXGqHUBM6vi/K5GVEMw2BDr8fNLY5W5kVEjoL6lErRml1hYh/mvIvrh4ecjkZNzMivoi5KWAeEXi8I2Ng3NGlqS//7m/jLyDt1gsW35pbx1p4sN2x2Cn05H6gmZnDtnBizKyz8IOChzgxPbsvouSMicpQUSmXcMoGZFWZ+0tS8KhPLGAqpA17A2sF61KTH9rS+VUbD1JjB/zqpnO1pn//x7kChL+ewPjU1wsWNNrZpsC3tc9Nmh9aU4qiIyLFQKBXJsU2YV2mxOBFOm5pVYRLOnwrtdf38oanmpE+P+vqMCAO4+dRybBOuXpEqypKKRASunB3jlAlhBdSz3Rke6HCL8lpFREqFakpFclwfVudWRSFDhQWLcquoi6stpsVM/nSKyZ/mTlV3DgyF1HVJj7QCybAIgPYBnxMqLWrLzKJbeTxlQtjqKRE1SGYCbtni8G5PadS+iogUM4VSkUPo9+DNvR5v7g0DxxTbyAfUwZP9dXGTs2qi+EFAS7+fbz21ud/H00LqMevIhdLG8uIJpbYJFzfYfGpa+EPJ23uz3N7qqIODiMgwUSgVOUK73IAXd2V5cVcWg/B0+OJEeLJ/fpXFCZXhx+drwfUD1uVWXZuTHh0DSqhHo9jGjTZVhK2easpMHC/g3jaX3+9SGhURGU4KpSLHICAcidmW8nlqe5aIQb6J/+KERVOFyUkTIpyUqzlMZgLW5OtRPXarVdBhFcu4URM4rzbK52ujmIbBpr6w1dOOEmzqLyJS7HTQSWQExC1YWGXla1Jr3xOuutND9ahrkh4plSQeoNyCG0+toC8b8H+tTBXkGqbFDJY3xZhTGbZ6eqQrw+NdavUkIjJStFIqMgIGPFixz8s3f58YNViUGJw0ZVJTFn4smxYFAlr7hyZNbez1Ge8H+1Me7HF9JtkmiYhBMju6X5BPTInwtZlhq6futM9NLQ4tR9kTV0REjo5WSkUKoLYsbOK/KGGxsMqibL8m/hk/YMN+TfzbUuOzif/fzI1x0oQI/7o+neuIMPIqI3DlrBinTgx/Xv/djgz3t6vVk4jIaNBKqUgBdKUDutJZftudxQSa9qtHnbvfrwH6s0NN/JuTHt3jpJ6xbcDnpAnQUG6wOjnyf99J1RZXzR5q9XRbq8M7JTLmVERkLFAoFSkwH9jU57Opz+fRrgy2CfOrwlC6JGHSUG5x2qQIp00Kv113u0OrqGuSHskxegg8fwJ/hA872SZ8pcHm07lWTyv3Zbl9izNmv64iIsVKoVSkyLg+vNvj5RuyJyIHNvGfbJt8YqrJJ6aGIao9tV8T/15vzGw1tw/kTuCPYFuoWeUmy+fEmFFm4voBP2tzeX6n0qiISCGoplSkxNTEjPz2/qKERXlkqB7VDwI29g2F1Ja+0q1HNYHbTivHD+Cqt1PD+nmYwGdmRLmgLmz11NLvcdNmZ9yURoiIFCOFUpESZgKN5WZ+FXV+pUnEHAqpaS9gbW+4zb+6x6MrXVrf7j9YXEZDucU/vJsatmufYoetnuZWWQRBwGPbMjzSqVZPIiKFpu17kRLmA60pn9aUzxPbM0QNmFs1dFBqdoXJ0gkRluaa+PdkfJqTPqt7wqC6t8h7T7UPBDSUh5OdutLHf+jo9MkRvj7Tpswy2OH43NzisKlPcVREpBhopVRkDKuwYOFgPWrCoqbswPrMrgE/P2lqba/HQJEdNj93epSLGmwe73J5sDNzzH9OhQVXzIrx4dxhsRd3ZrivzcVRHhURKRpaKRUZw/o9eGuvx1t7w7Q52TbytaiDk6Zq4yZn1kQJgoCW/qF61E19PqPcs/59huOw05KExVVNNhOiJv3ZgJ9ucfJDDUREpHhopVRkHKuPG7nWUxYLEhb2fvWorh+wvtdjTTKcNtWe8hntF4sJUYP/PKWc3a7PdasGjuqxUQMubLA5qybsUvBuT5Zbt7j0FHnJgojIeKVQKiIAWAbMqTDzk6bmVJiYxlBI7csG4SpqrkfqLnd0Xjr+e2k5FRGD5Sv6j7i8oCFucu2cGHVxk4wfcH+7y3M71OpJRKSYKZSKyEGVmbBgv3rUuvc0sd/hHNjEv3+EdsT/fn4MwzC4bYvDjg9o2WQA50yP8qX6KJZh0NrvcVOLw7YS6zogIjIeKZSKyBGpjhosTgyd7J9o7x9SA1r7Bw9N+azv9RiuXfKqCPQewSLnZNvg6qYYC3Ktnn69LcPDXRk8vcKJiJQEhVIROSbTywyW5ALqwoRF3Bra6s/6Bzbxb+0/vib+djRKXV0tdszGdVw6OrvIZIZO459UbfLNOWXELYNduVZPG9TqSUSkpCiUishxM4HZFUNN/OdWmlj71aOmsmET/+ZcE/8jnZxUXZ3g1KUns2D+XGzbzv++67qsW7+RFStX0dOTpMyE/7mwjPaUzz1bXdLKoyIiJUehVESGnW3CvEor3O6vtphZbh1w+x53aBW1uccneZDeU7W1Mzjvs2eTSCS46CtfwzBNTNPk7bfe4I+rVgLgOA6PPf4UXdu2EzUYtpIBEREZfQqlIjLiqiJDTfyXJCymxA48NNU5EIbU53dk6EoHVFcn+OpFXyQWCw85WZZFNpslGo1yxZXLufvOn5JOhy2iHMfh/gceoqcnWYhPTUREhoma54vIiOvNwh/2ePxhT3hEf2rMyB+YGjzZX1tm8NyOsE701KUnE4vFAAiCgGw2POlkWRaGYbBfZQCxWIxTl57M8y+8NLqflIiIDCuFUhEZdTudgBd2ZnlhZxYDaCw3mVFmsD0dYEejLJg/94D7x2IxvnrJZUycOJkXnn+GgYEDG+kvmD+Xl195/YDDTyIiUlqOfXafiMgwCICtKZ/Xc6uodXW1BxxqgnCL/s7bb+HmG/+LhYtOpLy84oDbbdumvq52tC5ZRERGgEKpiBQVO2Yf8rZUqp+dO7ZT39D4/sfZ0ZG8LBERGWEKpSJSVFzHPeD/y8sr8iundixGfcNM9uzZ/f7Hudq6FxEpZaopFZGi0tHZheu6+SCaqK7mL87+bO5wk8GKt//Arp07DniM64YN9UVEpHSpJZSIFJ1PffIMTjpx8ft+P5vN4vnv74zf3LyWl15+bTQuTURERohWSkWk6KxYuYr5807It4WCMJDedMudeF72CP4Eg/AIlYiIlAqFUhEpOj09SR779dOc99mz88HU8308L0vdFU9g2hWHfKzv9tN5x2dG61JFRGSYKJSKSFHq6trG/Q88xKlLTz6gb6lpV2DalQW8MhERGQkKpSJStHp6kjz/wku8/Mrr1M6YXujLERGREaSWUCJS9DKZDFvb2gt9GSIiMoIUSkVERESk4BRKRURERKTgFEpFREREpOAUSkVERESk4HT6XkRKiu/2H9ftIiJSnDRmVERKyJFOatJEJxGRUqPtexEpIUcaNBVIRURKjUKpiIiIiBScQqmIiIiIFJxCqYiIiIgUnEKpiIiIiBScQqmIiIiIFJxCqYiIiIgUnEKpiIiIiBScQqmIiIiIFJxCqYiIiIgUnEKpiIiIiBScQqmIiIiIFJxCqYiIiIgUnEKpiIiIiBScQqmIiIiIFJxCqYiIiIgU3P8PaN/Je9ylgc4AAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 29
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-08-03T12:22:06.328311702Z",
+     "start_time": "2026-08-03T12:22:06.310014106Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "plot_graph_interactive(graph)",
+   "id": "d545e60a2e1414ea",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<energnn.graph.plot.InteractiveGraphPlot at 0x7dbb78339940>"
+      ],
+      "text/html": [
+       "<style>#energnn-plot-3{--surface:#fcfcfb;--ink:#0b0b0b;--c0:#2a78d6;--c1:#eb6834;--c2:#1baf7a;--c3:#eda100;--c4:#e87ba4;--c5:#008300;--c6:#4a3aa7;--c7:#e34948;}@media (prefers-color-scheme: dark){#energnn-plot-3{--surface:#1a1a19;--ink:#ffffff;--c0:#3987e5;--c1:#d95926;--c2:#199e70;--c3:#c98500;--c4:#d55181;--c5:#008300;--c6:#9085e9;--c7:#e66767;}}#energnn-plot-3{position:relative;display:inline-block;font-family:system-ui,sans-serif;background:var(--surface);border-radius:6px}#energnn-plot-3 .lg{display:flex;flex-wrap:wrap;gap:4px 14px;padding:8px 12px 0;color:var(--ink);font-size:12px}#energnn-plot-3 .lg span{display:inline-flex;align-items:center;gap:5px}#energnn-plot-3 .obj .pl{opacity:0;fill:var(--ink);font-size:9px;pointer-events:none}#energnn-plot-3 .obj:hover .pl{opacity:1}#energnn-plot-3 .obj:hover line{stroke-width:4.4px}#energnn-plot-3 .obj:hover .mk,#energnn-plot-3 .addr:hover circle{stroke:var(--ink);stroke-width:1.5px}#energnn-plot-3 .tip{display:none;position:absolute;pointer-events:none;background:var(--surface);color:var(--ink);border:1px solid #898781;border-radius:4px;padding:5px 8px;font-size:11px;line-height:1.5;white-space:nowrap;z-index:10}</style><div id=\"energnn-plot-3\"><div class=\"lg\"><span><svg width=\"14\" height=\"14\"><circle cx=\"7\" cy=\"7\" r=\"5\" fill=\"#898781\"/></svg>addresses</span><span><svg width=\"14\" height=\"14\"><polygon class=\"mk\" points=\"2.5,2.5 11.5,2.5 11.5,11.5 2.5,11.5\" fill=\"var(--c0)\" /></svg>bus</span><span><svg width=\"14\" height=\"14\"><polygon class=\"mk\" points=\"7.0,1.6 11.9,10.8 2.0,10.8\" fill=\"var(--c1)\" /></svg>line</span></div><svg width=\"640\" height=\"640\" viewBox=\"0 0 640 640\"><g class=\"obj\" data-tip=\"&lt;b&gt;bus #0&lt;/b&gt;&lt;br&gt;id &amp;rarr; 0&lt;br&gt;active_power_injection = 2.0236\"><line x1=\"610.0\" y1=\"371.7\" x2=\"638.6\" y2=\"371.7\" stroke=\"var(--c0)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"625.7\" y=\"368.7\" text-anchor=\"middle\">id</text><polygon class=\"mk\" points=\"630.5,363.6 646.7,363.6 646.7,379.7 630.5,379.7\" fill=\"var(--c0)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;bus #1&lt;/b&gt;&lt;br&gt;id &amp;rarr; 1&lt;br&gt;active_power_injection = 1.0059\"><line x1=\"30.0\" y1=\"268.3\" x2=\"8.0\" y2=\"250.1\" stroke=\"var(--c0)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"17.9\" y=\"255.3\" text-anchor=\"middle\">id</text><polygon class=\"mk\" points=\"-0.1,242.0 16.0,242.0 16.0,258.1 -0.1,258.1\" fill=\"var(--c0)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;bus #2&lt;/b&gt;&lt;br&gt;id &amp;rarr; 2&lt;br&gt;active_power_injection = -0.7141\"><line x1=\"296.0\" y1=\"454.9\" x2=\"301.3\" y2=\"483.0\" stroke=\"var(--c0)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"298.9\" y=\"467.4\" text-anchor=\"middle\">id</text><polygon class=\"mk\" points=\"293.2,475.0 309.4,475.0 309.4,491.1 293.2,491.1\" fill=\"var(--c0)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;bus #3&lt;/b&gt;&lt;br&gt;id &amp;rarr; 3&lt;br&gt;active_power_injection = -2.3722\"><line x1=\"344.0\" y1=\"185.1\" x2=\"357.8\" y2=\"160.0\" stroke=\"var(--c0)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"351.6\" y=\"168.3\" text-anchor=\"middle\">id</text><polygon class=\"mk\" points=\"349.8,151.9 365.9,151.9 365.9,168.1 349.8,168.1\" fill=\"var(--c0)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;line #0&lt;/b&gt;&lt;br&gt;from &amp;rarr; 0&lt;br&gt;to &amp;rarr; 2&lt;br&gt;susceptance = 0.53553\"><line x1=\"610.0\" y1=\"371.7\" x2=\"296.0\" y2=\"454.9\" stroke=\"var(--c1)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"531.5\" y=\"389.5\" text-anchor=\"middle\">from</text><text class=\"pl\" x=\"374.5\" y=\"431.1\" text-anchor=\"middle\">to</text><polygon class=\"mk\" points=\"453.0,403.6 461.8,420.2 444.1,420.2\" fill=\"var(--c1)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;line #1&lt;/b&gt;&lt;br&gt;from &amp;rarr; 0&lt;br&gt;to &amp;rarr; 3&lt;br&gt;susceptance = 1.3079\"><line x1=\"610.0\" y1=\"371.7\" x2=\"344.0\" y2=\"185.1\" stroke=\"var(--c1)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"543.5\" y=\"322.0\" text-anchor=\"middle\">from</text><text class=\"pl\" x=\"410.5\" y=\"228.7\" text-anchor=\"middle\">to</text><polygon class=\"mk\" points=\"477.0,268.7 485.9,285.2 468.2,285.2\" fill=\"var(--c1)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;line #2&lt;/b&gt;&lt;br&gt;from &amp;rarr; 1&lt;br&gt;to &amp;rarr; 2&lt;br&gt;susceptance = 0.66472\"><line x1=\"30.0\" y1=\"268.3\" x2=\"296.0\" y2=\"454.9\" stroke=\"var(--c1)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"96.5\" y=\"312.0\" text-anchor=\"middle\">from</text><text class=\"pl\" x=\"229.5\" y=\"405.3\" text-anchor=\"middle\">to</text><polygon class=\"mk\" points=\"163.0,352.0 171.8,368.5 154.1,368.5\" fill=\"var(--c1)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;line #3&lt;/b&gt;&lt;br&gt;from &amp;rarr; 1&lt;br&gt;to &amp;rarr; 3&lt;br&gt;susceptance = 1.0497\"><line x1=\"30.0\" y1=\"268.3\" x2=\"344.0\" y2=\"185.1\" stroke=\"var(--c1)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"108.5\" y=\"244.5\" text-anchor=\"middle\">from</text><text class=\"pl\" x=\"265.5\" y=\"202.9\" text-anchor=\"middle\">to</text><polygon class=\"mk\" points=\"187.0,217.0 195.9,233.5 178.2,233.5\" fill=\"var(--c1)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"obj\" data-tip=\"&lt;b&gt;line #4&lt;/b&gt;&lt;br&gt;from &amp;rarr; 2&lt;br&gt;to &amp;rarr; 3&lt;br&gt;susceptance = 0.54477\"><line x1=\"296.0\" y1=\"454.9\" x2=\"344.0\" y2=\"185.1\" stroke=\"var(--c1)\" stroke-width=\"2.0\" stroke-opacity=\"0.85\"/><text class=\"pl\" x=\"308.0\" y=\"384.5\" text-anchor=\"middle\">from</text><text class=\"pl\" x=\"332.0\" y=\"249.5\" text-anchor=\"middle\">to</text><polygon class=\"mk\" points=\"320.0,310.3 328.9,326.9 311.1,326.9\" fill=\"var(--c1)\" stroke=\"var(--surface)\" stroke-width=\"1\"/></g><g class=\"addr\" data-tip=\"&lt;b&gt;address 0&lt;/b&gt;\"><circle cx=\"610.0\" cy=\"371.7\" r=\"13.0\" fill=\"#898781\"/><text x=\"610.0\" y=\"371.7\" text-anchor=\"middle\" dominant-baseline=\"central\" fill=\"#ffffff\" font-size=\"12\" pointer-events=\"none\">0</text></g><g class=\"addr\" data-tip=\"&lt;b&gt;address 1&lt;/b&gt;\"><circle cx=\"30.0\" cy=\"268.3\" r=\"13.0\" fill=\"#898781\"/><text x=\"30.0\" y=\"268.3\" text-anchor=\"middle\" dominant-baseline=\"central\" fill=\"#ffffff\" font-size=\"12\" pointer-events=\"none\">1</text></g><g class=\"addr\" data-tip=\"&lt;b&gt;address 2&lt;/b&gt;\"><circle cx=\"296.0\" cy=\"454.9\" r=\"13.0\" fill=\"#898781\"/><text x=\"296.0\" y=\"454.9\" text-anchor=\"middle\" dominant-baseline=\"central\" fill=\"#ffffff\" font-size=\"12\" pointer-events=\"none\">2</text></g><g class=\"addr\" data-tip=\"&lt;b&gt;address 3&lt;/b&gt;\"><circle cx=\"344.0\" cy=\"185.1\" r=\"13.0\" fill=\"#898781\"/><text x=\"344.0\" y=\"185.1\" text-anchor=\"middle\" dominant-baseline=\"central\" fill=\"#ffffff\" font-size=\"12\" pointer-events=\"none\">3</text></g></svg><div class=\"tip\"></div><script>(function(){var root=document.getElementById('energnn-plot-3');var tip=root.querySelector('.tip');root.querySelectorAll('[data-tip]').forEach(function(el){el.addEventListener('mousemove',function(e){tip.innerHTML=el.getAttribute('data-tip');tip.style.display='block';var r=root.getBoundingClientRect();tip.style.left=(e.clientX-r.left+14)+'px';tip.style.top=(e.clientY-r.top+14)+'px';});el.addEventListener('mouseleave',function(){tip.style.display='none';});});})();</script></div>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 30
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multi-graph support\n",
+    "\n",
+    "H2MGs are multi-graphs: several hyper-edges may connect the very same addresses.\n",
+    "Parallel edges are fanned out as curves and self-loops are drawn as small circles,\n",
+    "so every object stays visible and hoverable individually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from energnn.graph import Graph, HyperEdgeSet\n",
+    "\n",
+    "multi_graph = Graph.from_dict(\n",
+    "    hyper_edge_set_dict={\n",
+    "        # three parallel lines between addresses 0 and 1, one line 1-2, and a self-loop on 2\n",
+    "        \"line\": HyperEdgeSet.from_dict(\n",
+    "            port_dict={\"from\": np.array([0, 0, 0, 1, 2]), \"to\": np.array([1, 1, 1, 2, 2])},\n",
+    "            feature_dict={\"x\": np.array([0.1, 0.2, 0.3, 0.4, 0.5])},\n",
+    "        ),\n",
+    "        # two parallel three-winding transformers\n",
+    "        \"trafo3w\": HyperEdgeSet.from_dict(\n",
+    "            port_dict={\"hv\": np.array([0, 0]), \"mv\": np.array([1, 1]), \"lv\": np.array([2, 2])},\n",
+    "            feature_dict={\"ratio\": np.array([1.00, 1.05])},\n",
+    "        ),\n",
+    "    },\n",
+    "    n_addresses=3,\n",
+    ")\n",
+    "plot_graph_interactive(multi_graph)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom address coordinates\n",
+    "\n",
+    "Pass `positions` to place the addresses yourself instead of using the force-directed\n",
+    "layout — for instance latent coordinates computed by a coupler, or geographic\n",
+    "coordinates. The array must have one `(x, y)` row per address (padded length is\n",
+    "accepted, fictitious rows are dropped)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "positions = np.array([[0.0, 0.0], [4.0, 0.0], [2.0, 3.0]])\n",
+    "plot_graph_interactive(multi_graph, positions=positions)"
+   ]
   }
  ],
  "metadata": {

--- a/src/energnn/graph/__init__.py
+++ b/src/energnn/graph/__init__.py
@@ -18,6 +18,7 @@ from .hyper_edge_set import (
     separate_hyper_edge_sets,
 )
 from .jax.utils import jnp_to_np, np_to_jnp
+from .plot import plot_graph
 from .shape import GraphShape, collate_shapes, max_shape, separate_shapes, sum_shapes
 from .structure import GraphStructure, HyperEdgeSetStructure
 from .utils import to_numpy
@@ -39,6 +40,7 @@ __all__ = [
     "concatenate_graphs",
     "get_statistics",
     "separate_graphs",
+    "plot_graph",
     "check_hyper_edge_set_dict_type",
     "GraphShape",
     "collate_shapes",

--- a/src/energnn/graph/__init__.py
+++ b/src/energnn/graph/__init__.py
@@ -18,7 +18,7 @@ from .hyper_edge_set import (
     separate_hyper_edge_sets,
 )
 from .jax.utils import jnp_to_np, np_to_jnp
-from .plot import plot_graph
+from .plot import InteractiveGraphPlot, plot_graph, plot_graph_interactive
 from .shape import GraphShape, collate_shapes, max_shape, separate_shapes, sum_shapes
 from .structure import GraphStructure, HyperEdgeSetStructure
 from .utils import to_numpy
@@ -41,6 +41,8 @@ __all__ = [
     "get_statistics",
     "separate_graphs",
     "plot_graph",
+    "plot_graph_interactive",
+    "InteractiveGraphPlot",
     "check_hyper_edge_set_dict_type",
     "GraphShape",
     "collate_shapes",

--- a/src/energnn/graph/plot.py
+++ b/src/energnn/graph/plot.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
@@ -15,13 +15,42 @@ if TYPE_CHECKING:
 
     from energnn.graph.graph import Graph
 
-# Colorblind-validated categorical palette; slot order is part of the validation.
-_PALETTE = ["#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4", "#008300", "#4a3aa7", "#e34948"]
+
+class _Theme(NamedTuple):
+    palette: tuple[str, ...]
+    surface: str
+    ink: str
+
+
+# Colorblind-validated categorical palettes; slot order is part of the validation, and the
+# dark palette is the same hues re-stepped for a dark surface, not an automatic inversion.
+_THEMES = {
+    "light": _Theme(
+        palette=("#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4", "#008300", "#4a3aa7", "#e34948"),
+        surface="#fcfcfb",
+        ink="#0b0b0b",
+    ),
+    "dark": _Theme(
+        palette=("#3987e5", "#d95926", "#199e70", "#c98500", "#d55181", "#008300", "#9085e9", "#e66767"),
+        surface="#1a1a19",
+        ink="#ffffff",
+    ),
+}
 # Marker shapes double the color encoding so classes stay separable without color.
 _MARKERS = ["s", "^", "D", "v", "P", "X", "p", "*"]
 _ADDRESS_COLOR = "#898781"
-_SURFACE = "#fcfcfb"
-_INK = "#0b0b0b"
+
+
+def _resolve_theme(theme: str) -> str:
+    """Return "light" or "dark"; "auto" follows the luminance of matplotlib's figure facecolor."""
+    if theme in _THEMES:
+        return theme
+    if theme != "auto":
+        raise ValueError("theme must be 'light', 'dark' or 'auto'.")
+    import matplotlib
+
+    r, g, b = matplotlib.colors.to_rgb(matplotlib.rcParams["figure.facecolor"])
+    return "dark" if 0.2126 * r + 0.7152 * g + 0.0722 * b < 0.5 else "light"
 
 
 def spring_layout(n_nodes: int, edges: np.ndarray, *, iterations: int = 150, seed: int = 0) -> np.ndarray:
@@ -68,6 +97,7 @@ def plot_graph(
     iterations: int = 150,
     seed: int = 0,
     node_size: float | None = None,
+    theme: str = "auto",
 ) -> Axes:
     """
     Plot a single (non-batched) Graph with one color and marker per hyper-edge class.
@@ -87,9 +117,11 @@ def plot_graph(
     :param iterations: Number of layout relaxation steps.
     :param seed: Seed for the layout's random initial positions.
     :param node_size: Address marker area; inferred from the number of addresses when None.
+    :param theme: ``"light"``, ``"dark"``, or ``"auto"`` to follow matplotlib's current
+        figure facecolor (e.g. dark notebook themes).
     :return: The matplotlib Axes containing the plot.
     :raises ImportError: If matplotlib is not installed.
-    :raises ValueError: If the graph is not single.
+    :raises ValueError: If the graph is not single, or if ``theme`` is invalid.
     """
     try:
         import matplotlib.pyplot as plt
@@ -98,6 +130,8 @@ def plot_graph(
 
     if not graph.is_single:
         raise ValueError("plot_graph only handles single graphs; use separate_graphs() on a batch first.")
+
+    palette, surface, ink = _THEMES[_resolve_theme(theme)]
 
     g = graph.to_numpy_backend()
     n_addr = int(np.asarray(g.non_fictitious_addresses).sum())
@@ -132,13 +166,14 @@ def plot_graph(
     pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
 
     if ax is None:
-        _, ax = plt.subplots(figsize=(7, 7))
-    ax.set_facecolor(_SURFACE)
+        fig, ax = plt.subplots(figsize=(7, 7))
+        fig.set_facecolor(surface)
+    ax.set_facecolor(surface)
     ax.set_aspect("equal")
     ax.axis("off")
 
     for class_index, name in enumerate(classes):
-        color = _PALETTE[class_index % len(_PALETTE)]
+        color = palette[class_index % len(palette)]
         segments_x: list[Any] = []
         segments_y: list[Any] = []
         for i, edge_ports in enumerate(edges_by_class[name]):
@@ -159,7 +194,7 @@ def plot_graph(
         pos[:n_addr, 1],
         s=node_size,
         c=_ADDRESS_COLOR,
-        edgecolors=_SURFACE,
+        edgecolors=surface,
         linewidths=1.5,
         zorder=3,
         label="addresses",
@@ -169,7 +204,7 @@ def plot_graph(
             ax.annotate(str(i), pos[i], ha="center", va="center", fontsize=7, color="#ffffff", zorder=4)
 
     for class_index, name in enumerate(classes):
-        color = _PALETTE[class_index % len(_PALETTE)]
+        color = palette[class_index % len(palette)]
         marker = _MARKERS[class_index % len(_MARKERS)]
         xs, ys = [], []
         for i, edge_ports in enumerate(edges_by_class[name]):
@@ -187,8 +222,8 @@ def plot_graph(
             ys.append(point[1])
         if xs:
             ax.scatter(
-                xs, ys, s=0.45 * node_size, c=color, marker=marker, edgecolors=_SURFACE, linewidths=0.8, zorder=3.5, label=name
+                xs, ys, s=0.45 * node_size, c=color, marker=marker, edgecolors=surface, linewidths=0.8, zorder=3.5, label=name
             )
 
-    ax.legend(loc="upper left", bbox_to_anchor=(1.0, 1.0), frameon=False, labelcolor=_INK, fontsize=9)
+    ax.legend(loc="upper left", bbox_to_anchor=(1.0, 1.0), frameon=False, labelcolor=ink, fontsize=9)
     return ax

--- a/src/energnn/graph/plot.py
+++ b/src/energnn/graph/plot.py
@@ -104,13 +104,19 @@ class _PlotData(NamedTuple):
     hub_ids: dict[tuple[str, int], int]  # (class, object index) -> hub row in pos
 
 
-def _extract_plot_data(graph: Graph, *, iterations: int, seed: int) -> _PlotData:
-    """Collect real (non-fictitious) objects of a single Graph and lay them out."""
+def _extract_plot_data(graph: Graph, *, iterations: int, seed: int, positions: Any = None) -> _PlotData:
+    """Collect real (non-fictitious) objects of a single Graph and lay them out.
+
+    When ``positions`` is given, it provides the address coordinates (real addresses,
+    or padded length — fictitious rows are dropped); hyper-edge hubs are then placed
+    at the barycenter of their ports instead of being laid out by the spring model.
+    """
     if not graph.is_single:
         raise ValueError("plot_graph only handles single graphs; use separate_graphs() on a batch first.")
 
     g = graph.to_numpy_backend()
-    n_addr = int(np.asarray(g.non_fictitious_addresses).sum())
+    address_mask = np.asarray(g.non_fictitious_addresses) > 0
+    n_addr = int(address_mask.sum())
 
     classes = sorted(g.hyper_edge_sets)
     ports: dict[str, list[list[int]]] = {}
@@ -146,9 +152,105 @@ def _extract_plot_data(graph: Graph, *, iterations: int, seed: int) -> _PlotData
                 hub_ids[(name, i)] = next_id
                 layout_edges.extend((next_id, p) for p in edge_ports)
                 next_id += 1
-    pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
+
+    if positions is None:
+        pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
+    else:
+        addr_pos = np.asarray(positions, dtype=float)
+        if addr_pos.ndim == 2 and addr_pos.shape[0] == len(address_mask):
+            addr_pos = addr_pos[address_mask]
+        if addr_pos.shape != (n_addr, 2):
+            raise ValueError(f"positions must have shape ({n_addr}, 2) or (current addresses, 2); got {addr_pos.shape}.")
+        # Normalize to the [-1, 1] layout box so marker sizes and offsets stay consistent.
+        addr_pos = addr_pos - addr_pos.mean(axis=0)
+        scale = np.abs(addr_pos).max()
+        if scale > 0:
+            addr_pos = addr_pos / scale
+        pos = np.zeros((next_id, 2))
+        pos[:n_addr] = addr_pos
+        for (name, i), hub_id in hub_ids.items():
+            pos[hub_id] = addr_pos[ports[name][i]].mean(axis=0)
 
     return _PlotData(n_addr, classes, ports, port_names, features, pos, hub_ids)
+
+
+class _ObjGeom(NamedTuple):
+    lines: list[np.ndarray]  # polylines of shape (k, 2), layout coordinates
+    marker: np.ndarray  # marker position, shape (2,)
+    labels: list[np.ndarray]  # one label anchor per port
+
+
+_BEZIER_T = np.linspace(0.0, 1.0, 17)[:, None]
+
+
+def _bezier(a: np.ndarray, control: np.ndarray, b: np.ndarray) -> np.ndarray:
+    t = _BEZIER_T
+    return (1 - t) ** 2 * a + 2 * t * (1 - t) * control + t**2 * b
+
+
+def _rotate(u: np.ndarray, phi: float) -> np.ndarray:
+    c, s = np.cos(phi), np.sin(phi)
+    return np.array([c * u[0] - s * u[1], s * u[0] + c * u[1]])
+
+
+def _object_geometries(data: _PlotData) -> dict[tuple[str, int], _ObjGeom]:
+    """
+    Geometry of every hyper-edge object, in layout coordinates.
+
+    Order-2 edges sharing the same address pair (across all classes) are fanned out
+    as symmetric Bezier curves so parallel edges stay distinguishable, and
+    self-loops are drawn as small circles attached to their address.
+    """
+    pos = data.pos
+
+    pair_groups: dict[tuple[int, int], list[tuple[str, int]]] = {}
+    for name in data.classes:
+        for i, edge_ports in enumerate(data.ports[name]):
+            if len(edge_ports) == 2:
+                pair = (min(edge_ports), max(edge_ports))
+                pair_groups.setdefault(pair, []).append((name, i))
+
+    fan: dict[tuple[str, int], float] = {}
+    loop_rank: dict[tuple[str, int], tuple[int, int]] = {}
+    for (addr_a, addr_b), members in pair_groups.items():
+        for j, member in enumerate(members):
+            if addr_a == addr_b:
+                loop_rank[member] = (j, len(members))
+            else:
+                fan[member] = j - (len(members) - 1) / 2.0
+
+    geoms: dict[tuple[str, int], _ObjGeom] = {}
+    for class_index, name in enumerate(data.classes):
+        for i, edge_ports in enumerate(data.ports[name]):
+            key = (name, i)
+            if len(edge_ports) == 1:
+                # Deterministic radial offset so several order-1 edges on one address stay visible.
+                angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
+                tip = pos[edge_ports[0]] + 0.05 * np.array([np.cos(angle), np.sin(angle)])
+                geoms[key] = _ObjGeom([np.stack([pos[edge_ports[0]], tip])], tip, [(pos[edge_ports[0]] + tip) / 2.0])
+            elif key in loop_rank:
+                # Self-loop: a small circle beside the address; several loops spread around it.
+                j, m = loop_rank[key]
+                u = np.array([np.cos(2.0 * np.pi * j / m + 0.6), np.sin(2.0 * np.pi * j / m + 0.6)])
+                r_loop = 0.055
+                center = pos[edge_ports[0]] + 1.7 * r_loop * u
+                theta = np.linspace(0.0, 2.0 * np.pi, 25)[:, None]
+                circle = center + r_loop * np.concatenate([np.cos(theta), np.sin(theta)], axis=1)
+                labels = [center + 1.6 * r_loop * _rotate(u, 0.9), center + 1.6 * r_loop * _rotate(u, -0.9)]
+                geoms[key] = _ObjGeom([circle], center + r_loop * u, labels)
+            elif len(edge_ports) == 2:
+                a, b = pos[edge_ports[0]], pos[edge_ports[1]]
+                chord = b - a
+                length = max(float(np.linalg.norm(chord)), 1e-9)
+                normal = np.array([-chord[1], chord[0]]) / length
+                height = fan[key] * min(0.3 * length, 0.09)
+                curve = _bezier(a, (a + b) / 2.0 + 2.0 * height * normal, b)
+                geoms[key] = _ObjGeom([curve], curve[8], [curve[3], curve[13]])
+            elif len(edge_ports) >= 3:
+                hub = pos[data.hub_ids[key]]
+                lines = [np.stack([hub, pos[p]]) for p in edge_ports]
+                geoms[key] = _ObjGeom(lines, hub, [(hub + pos[p]) / 2.0 for p in edge_ports])
+    return geoms
 
 
 def plot_graph(
@@ -157,6 +259,7 @@ def plot_graph(
     ax: Axes | None = None,
     address_labels: bool = True,
     port_labels: bool = False,
+    positions: Any = None,
     iterations: int = 150,
     seed: int = 0,
     node_size: float | None = None,
@@ -180,7 +283,10 @@ def plot_graph(
     :param ax: Axes to draw into; a new figure is created when None.
     :param address_labels: If True, write the address index on each address node.
     :param port_labels: If True, write the port name along each port connection.
-    :param iterations: Number of layout relaxation steps.
+    :param positions: Optional address coordinates of shape ``(n_addresses, 2)`` (e.g.
+        latent coordinates from a coupler); replaces the force-directed layout. Padded
+        graphs may pass the padded length, fictitious rows are dropped.
+    :param iterations: Number of layout relaxation steps (unused when ``positions`` is given).
     :param seed: Seed for the layout's random initial positions.
     :param node_size: Address marker area; inferred from the number of addresses when None.
     :param theme: ``"light"``, ``"dark"``, or ``"auto"`` to follow matplotlib's current
@@ -195,8 +301,9 @@ def plot_graph(
         raise ImportError("plot_graph requires matplotlib; install it with 'pip install matplotlib'.") from exc
 
     palette, surface, ink = _THEMES[_resolve_theme(theme)]
-    data = _extract_plot_data(graph, iterations=iterations, seed=seed)
+    data = _extract_plot_data(graph, iterations=iterations, seed=seed, positions=positions)
     n_addr, pos = data.n_addr, data.pos
+    geoms = _object_geometries(data)
 
     if node_size is None:
         node_size = float(np.clip(4000.0 / max(n_addr, 1), 12.0, 130.0))
@@ -216,21 +323,16 @@ def plot_graph(
         color = palette[class_index % len(palette)]
         segments_x: list[Any] = []
         segments_y: list[Any] = []
-        for i, edge_ports in enumerate(data.ports[name]):
-            if len(edge_ports) == 2:
-                a, b = pos[edge_ports[0]], pos[edge_ports[1]]
-                segments_x += [a[0], b[0], None]
-                segments_y += [a[1], b[1], None]
-                if port_labels:
-                    _port_label(data.port_names[name][0], a + 0.22 * (b - a))
-                    _port_label(data.port_names[name][1], b + 0.22 * (a - b))
-            elif len(edge_ports) >= 3:
-                hub = pos[data.hub_ids[(name, i)]]
-                for port_index, p in enumerate(edge_ports):
-                    segments_x += [hub[0], pos[p][0], None]
-                    segments_y += [hub[1], pos[p][1], None]
-                    if port_labels:
-                        _port_label(data.port_names[name][port_index], (hub + pos[p]) / 2.0)
+        for i in range(len(data.ports[name])):
+            geom = geoms.get((name, i))
+            if geom is None:
+                continue
+            for line in geom.lines:
+                segments_x += list(line[:, 0]) + [None]
+                segments_y += list(line[:, 1]) + [None]
+            if port_labels:
+                for port_name, at in zip(data.port_names[name], geom.labels):
+                    _port_label(port_name, at)
         if segments_x:
             ax.plot(segments_x, segments_y, color=color, linewidth=line_width, alpha=0.85, zorder=1)
 
@@ -252,21 +354,12 @@ def plot_graph(
         color = palette[class_index % len(palette)]
         marker = _MARKERS[class_index % len(_MARKERS)]
         xs, ys = [], []
-        for i, edge_ports in enumerate(data.ports[name]):
-            if len(edge_ports) == 1:
-                # Deterministic radial offset so several order-1 edges on one address stay visible.
-                angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
-                point = pos[edge_ports[0]] + 0.045 * np.array([np.cos(angle), np.sin(angle)])
-                if port_labels:
-                    _port_label(data.port_names[name][0], point + np.array([0.0, -0.03]))
-            elif len(edge_ports) == 2:
-                point = (pos[edge_ports[0]] + pos[edge_ports[1]]) / 2.0
-            elif len(edge_ports) >= 3:
-                point = pos[data.hub_ids[(name, i)]]
-            else:
+        for i in range(len(data.ports[name])):
+            geom = geoms.get((name, i))
+            if geom is None:
                 continue
-            xs.append(point[0])
-            ys.append(point[1])
+            xs.append(geom.marker[0])
+            ys.append(geom.marker[1])
         if xs:
             ax.scatter(
                 xs, ys, s=0.45 * node_size, c=color, marker=marker, edgecolors=surface, linewidths=0.8, zorder=3.5, label=name
@@ -340,6 +433,7 @@ def _tip(title: str, port_lines: list[tuple[str, int]], feature_lines: dict[str,
 def plot_graph_interactive(
     graph: Graph,
     *,
+    positions: Any = None,
     iterations: int = 150,
     seed: int = 0,
     size: int = 640,
@@ -350,13 +444,17 @@ def plot_graph_interactive(
 
     Address indices are always visible; hovering any object (address, hyper-edge
     marker or line) shows a tooltip with its port addresses and feature values, and
-    reveals the port names along its connections. The result displays inline in
+    reveals the port names along its connections. The mouse wheel zooms, dragging
+    pans, and double-click resets the view. The result displays inline in
     Jupyter/IDE notebooks (via ``_repr_html_``) and can be written to a standalone
     HTML file with :meth:`InteractiveGraphPlot.save`. No dependency is required.
 
     :param graph: A single Graph; batched graphs must first go through
         :func:`energnn.graph.separate_graphs`.
-    :param iterations: Number of layout relaxation steps.
+    :param positions: Optional address coordinates of shape ``(n_addresses, 2)`` (e.g.
+        latent coordinates from a coupler); replaces the force-directed layout. Padded
+        graphs may pass the padded length, fictitious rows are dropped.
+    :param iterations: Number of layout relaxation steps (unused when ``positions`` is given).
     :param seed: Seed for the layout's random initial positions.
     :param size: Width and height of the drawing, in pixels.
     :param theme: ``"light"``, ``"dark"``, or ``"auto"`` to follow the viewer's
@@ -367,11 +465,16 @@ def plot_graph_interactive(
     if theme not in ("light", "dark", "auto"):
         raise ValueError("theme must be 'light', 'dark' or 'auto'.")
 
-    data = _extract_plot_data(graph, iterations=iterations, seed=seed)
-    n_addr, pos = data.n_addr, data.pos
+    data = _extract_plot_data(graph, iterations=iterations, seed=seed, positions=positions)
+    n_addr = data.n_addr
+    geoms = _object_geometries(data)
 
     pad = 30.0
-    xy = (pos + 1.0) / 2.0 * (size - 2 * pad) + pad
+
+    def _to_px(points: np.ndarray) -> np.ndarray:
+        return (points + 1.0) / 2.0 * (size - 2 * pad) + pad
+
+    xy = _to_px(data.pos)
     r_addr = float(np.clip(150.0 / np.sqrt(max(n_addr, 1)), 5.0, 13.0))
     r_mark = 0.62 * r_addr
     stroke = float(np.clip(r_addr / 6.0, 1.0, 2.0))
@@ -396,11 +499,13 @@ def plot_graph_interactive(
         f"#{uid} .lg span{{display:inline-flex;align-items:center;gap:5px}}"
         f"#{uid} .obj .pl{{opacity:0;fill:var(--ink);font-size:9px;pointer-events:none}}"
         f"#{uid} .obj:hover .pl{{opacity:1}}"
-        f"#{uid} .obj:hover line{{stroke-width:{2.2 * stroke:.1f}px}}"
+        f"#{uid} .obj:hover polyline{{stroke-width:{2.2 * stroke:.1f}px}}"
         f"#{uid} .obj:hover .mk,#{uid} .addr:hover circle{{stroke:var(--ink);stroke-width:1.5px}}"
         f"#{uid} .tip{{display:none;position:absolute;pointer-events:none;background:var(--surface);color:var(--ink);"
         f"border:1px solid {_ADDRESS_COLOR};border-radius:4px;padding:5px 8px;font-size:11px;line-height:1.5;"
         f"white-space:nowrap;z-index:10}}"
+        f"#{uid} svg.cv{{cursor:grab}}"
+        f"#{uid} svg.cv:active{{cursor:grabbing}}"
     )
 
     svg: list[str] = []
@@ -416,37 +521,23 @@ def plot_graph_interactive(
         )
         port_names = data.port_names[name]
         for i, edge_ports in enumerate(data.ports[name]):
+            geom = geoms.get((name, i))
+            if geom is None:
+                continue
             tip = _tip(f"{name} #{i}", list(zip(port_names, edge_ports)), data.features[name][i])
             body: list[str] = []
-
-            def _spoke(a: np.ndarray, b: np.ndarray, label: str, frac: float = 0.5) -> None:
+            for line in geom.lines:
+                points_attr = " ".join(f"{x:.1f},{y:.1f}" for x, y in _to_px(line))
                 body.append(
-                    f'<line x1="{a[0]:.1f}" y1="{a[1]:.1f}" x2="{b[0]:.1f}" y2="{b[1]:.1f}"'
+                    f'<polyline points="{points_attr}" fill="none"'
                     f' stroke="{color_var}" stroke-width="{stroke:.1f}" stroke-opacity="0.85"/>'
                 )
-                at = a + frac * (b - a)
+            for port_name, at in zip(port_names, geom.labels):
+                p = _to_px(at)
                 body.append(
-                    f'<text class="pl" x="{at[0]:.1f}" y="{at[1] - 3:.1f}" text-anchor="middle">{html.escape(label)}</text>'
+                    f'<text class="pl" x="{p[0]:.1f}" y="{p[1] - 3:.1f}" text-anchor="middle">{html.escape(port_name)}</text>'
                 )
-
-            if len(edge_ports) == 1:
-                angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
-                point = xy[edge_ports[0]] + 2.2 * r_addr * np.array([np.cos(angle), np.sin(angle)])
-                _spoke(xy[edge_ports[0]], point, port_names[0], frac=0.55)
-            elif len(edge_ports) == 2:
-                a, b = xy[edge_ports[0]], xy[edge_ports[1]]
-                _spoke(a, b, port_names[0], frac=0.25)
-                body.append(
-                    f'<text class="pl" x="{(b + 0.25 * (a - b))[0]:.1f}" y="{(b + 0.25 * (a - b))[1] - 3:.1f}"'
-                    f' text-anchor="middle">{html.escape(port_names[1])}</text>'
-                )
-                point = (a + b) / 2.0
-            elif len(edge_ports) >= 3:
-                point = xy[data.hub_ids[(name, i)]]
-                for port_index, p in enumerate(edge_ports):
-                    _spoke(point, xy[p], port_names[port_index])
-            else:
-                continue
+            point = _to_px(geom.marker)
             body.append(_svg_marker(shape, point[0], point[1], r_mark, color_var, 'stroke="var(--surface)" stroke-width="1"'))
             svg.append(f'<g class="obj" data-tip="{tip}">{"".join(body)}</g>')
 
@@ -466,13 +557,25 @@ def plot_graph_interactive(
         f"el.addEventListener('mousemove',function(e){{tip.innerHTML=el.getAttribute('data-tip');"
         f"tip.style.display='block';var r=root.getBoundingClientRect();"
         f"tip.style.left=(e.clientX-r.left+14)+'px';tip.style.top=(e.clientY-r.top+14)+'px';}});"
-        f"el.addEventListener('mouseleave',function(){{tip.style.display='none';}});}});}})();"
+        f"el.addEventListener('mouseleave',function(){{tip.style.display='none';}});}});"
+        # wheel to zoom on the cursor, drag to pan, double-click to reset
+        f"var svg=root.querySelector('svg.cv');var vb=[0,0,{size},{size}];var drag=null;"
+        f"function apply(){{svg.setAttribute('viewBox',vb.join(' '));}}"
+        f"svg.addEventListener('wheel',function(e){{e.preventDefault();"
+        f"var k=e.deltaY<0?0.8:1.25;var r=svg.getBoundingClientRect();"
+        f"var mx=vb[0]+(e.clientX-r.left)/r.width*vb[2];var my=vb[1]+(e.clientY-r.top)/r.height*vb[3];"
+        f"vb=[mx-(mx-vb[0])*k,my-(my-vb[1])*k,vb[2]*k,vb[3]*k];apply();}},{{passive:false}});"
+        f"svg.addEventListener('mousedown',function(e){{e.preventDefault();drag=[e.clientX,e.clientY,vb[0],vb[1]];}});"
+        f"window.addEventListener('mousemove',function(e){{if(drag){{var r=svg.getBoundingClientRect();"
+        f"vb[0]=drag[2]-(e.clientX-drag[0])/r.width*vb[2];vb[1]=drag[3]-(e.clientY-drag[1])/r.height*vb[3];apply();}}}});"
+        f"window.addEventListener('mouseup',function(){{drag=null;}});"
+        f"svg.addEventListener('dblclick',function(){{vb=[0,0,{size},{size}];apply();}});}})();"
     )
 
     fragment = (
         f"<style>{css}</style>"
         f'<div id="{uid}"><div class="lg">{"".join(legend)}</div>'
-        f'<svg width="{size}" height="{size}" viewBox="0 0 {size} {size}">{"".join(svg)}</svg>'
+        f'<svg class="cv" width="{size}" height="{size}" viewBox="0 0 {size} {size}">{"".join(svg)}</svg>'
         f'<div class="tip"></div><script>{script}</script></div>'
     )
     return InteractiveGraphPlot(fragment)

--- a/src/energnn/graph/plot.py
+++ b/src/energnn/graph/plot.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import html
+import itertools
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
@@ -38,7 +40,10 @@ _THEMES = {
 }
 # Marker shapes double the color encoding so classes stay separable without color.
 _MARKERS = ["s", "^", "D", "v", "P", "X", "p", "*"]
+_SVG_MARKERS = ["square", "triangle-up", "diamond", "triangle-down", "plus", "cross", "pentagon", "star"]
 _ADDRESS_COLOR = "#898781"
+
+_plot_ids = itertools.count()
 
 
 def _resolve_theme(theme: str) -> str:
@@ -89,11 +94,69 @@ def spring_layout(n_nodes: int, edges: np.ndarray, *, iterations: int = 150, see
     return pos / scale if scale > 0 else pos
 
 
+class _PlotData(NamedTuple):
+    n_addr: int
+    classes: list[str]
+    ports: dict[str, list[list[int]]]  # class -> per real object, port addresses (sorted port order)
+    port_names: dict[str, list[str]]  # class -> sorted port names
+    features: dict[str, list[dict[str, float]]]  # class -> per real object, feature name -> value
+    pos: np.ndarray  # star-expansion layout: addresses then hubs
+    hub_ids: dict[tuple[str, int], int]  # (class, object index) -> hub row in pos
+
+
+def _extract_plot_data(graph: Graph, *, iterations: int, seed: int) -> _PlotData:
+    """Collect real (non-fictitious) objects of a single Graph and lay them out."""
+    if not graph.is_single:
+        raise ValueError("plot_graph only handles single graphs; use separate_graphs() on a batch first.")
+
+    g = graph.to_numpy_backend()
+    n_addr = int(np.asarray(g.non_fictitious_addresses).sum())
+
+    classes = sorted(g.hyper_edge_sets)
+    ports: dict[str, list[list[int]]] = {}
+    port_names: dict[str, list[str]] = {}
+    features: dict[str, list[dict[str, float]]] = {}
+    for name in classes:
+        hes = g.hyper_edge_sets[name]
+        mask = np.asarray(hes.non_fictitious) > 0
+        if hes.port_dict is not None:
+            port_names[name] = sorted(hes.port_dict)
+            stacked = np.stack([np.asarray(hes.port_dict[k]) for k in port_names[name]], axis=-1)
+            ports[name] = [list(map(int, row)) for row in stacked[mask]]
+        else:
+            port_names[name] = []
+            ports[name] = [[] for _ in range(int(mask.sum()))]
+        if hes.feature_names is not None:
+            feature_array = np.asarray(hes.feature_array)[mask]
+            features[name] = [
+                {fn: float(feature_array[j, int(idx)]) for fn, idx in sorted(hes.feature_names.items())}
+                for j in range(len(feature_array))
+            ]
+        else:
+            features[name] = [{} for _ in range(len(ports[name]))]
+
+    layout_edges: list[tuple[int, int]] = []
+    hub_ids: dict[tuple[str, int], int] = {}
+    next_id = n_addr
+    for name in classes:
+        for i, edge_ports in enumerate(ports[name]):
+            if len(edge_ports) == 2:
+                layout_edges.append((edge_ports[0], edge_ports[1]))
+            elif len(edge_ports) >= 3:
+                hub_ids[(name, i)] = next_id
+                layout_edges.extend((next_id, p) for p in edge_ports)
+                next_id += 1
+    pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
+
+    return _PlotData(n_addr, classes, ports, port_names, features, pos, hub_ids)
+
+
 def plot_graph(
     graph: Graph,
     *,
     ax: Axes | None = None,
-    address_labels: bool = False,
+    address_labels: bool = True,
+    port_labels: bool = False,
     iterations: int = 150,
     seed: int = 0,
     node_size: float | None = None,
@@ -108,12 +171,15 @@ def plot_graph(
     hub marker connected to all their ports. Fictitious (padded) objects and
     addresses are skipped.
 
+    For an interactive version with feature tooltips, see :func:`plot_graph_interactive`.
+
     Requires ``matplotlib``.
 
     :param graph: A single Graph; batched graphs must first go through
         :func:`energnn.graph.separate_graphs`.
     :param ax: Axes to draw into; a new figure is created when None.
     :param address_labels: If True, write the address index on each address node.
+    :param port_labels: If True, write the port name along each port connection.
     :param iterations: Number of layout relaxation steps.
     :param seed: Seed for the layout's random initial positions.
     :param node_size: Address marker area; inferred from the number of addresses when None.
@@ -128,42 +194,13 @@ def plot_graph(
     except ImportError as exc:
         raise ImportError("plot_graph requires matplotlib; install it with 'pip install matplotlib'.") from exc
 
-    if not graph.is_single:
-        raise ValueError("plot_graph only handles single graphs; use separate_graphs() on a batch first.")
-
     palette, surface, ink = _THEMES[_resolve_theme(theme)]
+    data = _extract_plot_data(graph, iterations=iterations, seed=seed)
+    n_addr, pos = data.n_addr, data.pos
 
-    g = graph.to_numpy_backend()
-    n_addr = int(np.asarray(g.non_fictitious_addresses).sum())
     if node_size is None:
         node_size = float(np.clip(4000.0 / max(n_addr, 1), 12.0, 130.0))
     line_width = float(np.clip(1.4 * np.sqrt(node_size / 130.0), 0.7, 1.4))
-
-    # Collect the port lists of real (non-fictitious) hyper-edges, per class.
-    classes = sorted(g.hyper_edge_sets)
-    edges_by_class: dict[str, list[list[int]]] = {}
-    for name in classes:
-        hes = g.hyper_edge_sets[name]
-        mask = np.asarray(hes.non_fictitious) > 0
-        if hes.port_dict is None:
-            edges_by_class[name] = []
-            continue
-        ports = np.stack([np.asarray(hes.port_dict[k]) for k in sorted(hes.port_dict)], axis=-1)
-        edges_by_class[name] = [list(map(int, row)) for row in ports[mask]]
-
-    # Star expansion for the layout: addresses in [0, n_addr), then one hub per order>=3 edge.
-    layout_edges: list[tuple[int, int]] = []
-    hub_ids: dict[tuple[str, int], int] = {}
-    next_id = n_addr
-    for name in classes:
-        for i, edge_ports in enumerate(edges_by_class[name]):
-            if len(edge_ports) == 2:
-                layout_edges.append((edge_ports[0], edge_ports[1]))
-            elif len(edge_ports) >= 3:
-                hub_ids[(name, i)] = next_id
-                layout_edges.extend((next_id, p) for p in edge_ports)
-                next_id += 1
-    pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
 
     if ax is None:
         fig, ax = plt.subplots(figsize=(7, 7))
@@ -172,20 +209,28 @@ def plot_graph(
     ax.set_aspect("equal")
     ax.axis("off")
 
-    for class_index, name in enumerate(classes):
+    def _port_label(text: str, at: np.ndarray) -> None:
+        ax.annotate(text, (float(at[0]), float(at[1])), ha="center", va="center", fontsize=6, color=_ADDRESS_COLOR, zorder=4)
+
+    for class_index, name in enumerate(data.classes):
         color = palette[class_index % len(palette)]
         segments_x: list[Any] = []
         segments_y: list[Any] = []
-        for i, edge_ports in enumerate(edges_by_class[name]):
+        for i, edge_ports in enumerate(data.ports[name]):
             if len(edge_ports) == 2:
                 a, b = pos[edge_ports[0]], pos[edge_ports[1]]
                 segments_x += [a[0], b[0], None]
                 segments_y += [a[1], b[1], None]
+                if port_labels:
+                    _port_label(data.port_names[name][0], a + 0.22 * (b - a))
+                    _port_label(data.port_names[name][1], b + 0.22 * (a - b))
             elif len(edge_ports) >= 3:
-                hub = pos[hub_ids[(name, i)]]
-                for p in edge_ports:
+                hub = pos[data.hub_ids[(name, i)]]
+                for port_index, p in enumerate(edge_ports):
                     segments_x += [hub[0], pos[p][0], None]
                     segments_y += [hub[1], pos[p][1], None]
+                    if port_labels:
+                        _port_label(data.port_names[name][port_index], (hub + pos[p]) / 2.0)
         if segments_x:
             ax.plot(segments_x, segments_y, color=color, linewidth=line_width, alpha=0.85, zorder=1)
 
@@ -203,19 +248,21 @@ def plot_graph(
         for i in range(n_addr):
             ax.annotate(str(i), pos[i], ha="center", va="center", fontsize=7, color="#ffffff", zorder=4)
 
-    for class_index, name in enumerate(classes):
+    for class_index, name in enumerate(data.classes):
         color = palette[class_index % len(palette)]
         marker = _MARKERS[class_index % len(_MARKERS)]
         xs, ys = [], []
-        for i, edge_ports in enumerate(edges_by_class[name]):
+        for i, edge_ports in enumerate(data.ports[name]):
             if len(edge_ports) == 1:
                 # Deterministic radial offset so several order-1 edges on one address stay visible.
                 angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
                 point = pos[edge_ports[0]] + 0.045 * np.array([np.cos(angle), np.sin(angle)])
+                if port_labels:
+                    _port_label(data.port_names[name][0], point + np.array([0.0, -0.03]))
             elif len(edge_ports) == 2:
                 point = (pos[edge_ports[0]] + pos[edge_ports[1]]) / 2.0
             elif len(edge_ports) >= 3:
-                point = pos[hub_ids[(name, i)]]
+                point = pos[data.hub_ids[(name, i)]]
             else:
                 continue
             xs.append(point[0])
@@ -227,3 +274,205 @@ def plot_graph(
 
     ax.legend(loc="upper left", bbox_to_anchor=(1.0, 1.0), frameon=False, labelcolor=ink, fontsize=9)
     return ax
+
+
+# ---------------------------------------------------------------------------
+# Interactive (HTML/SVG) plot
+# ---------------------------------------------------------------------------
+
+
+class InteractiveGraphPlot:
+    """Self-contained HTML/SVG rendering of a Graph, displayed inline by notebooks."""
+
+    def __init__(self, html_fragment: str) -> None:
+        self._html = html_fragment
+
+    def _repr_html_(self) -> str:
+        return self._html
+
+    def save(self, file_path: str) -> None:
+        """Write the plot as a standalone HTML page."""
+        with open(file_path, "w", encoding="utf-8") as handle:
+            handle.write(
+                "<!DOCTYPE html>\n<html><head><meta charset='utf-8'></head><body>\n" + self._html + "\n</body></html>"
+            )
+
+
+def _marker_points(shape: str, r: float) -> list[tuple[float, float]]:
+    """Vertices of a marker polygon of nominal radius ``r`` centered on the origin."""
+    if shape == "square":
+        return [(-r, -r), (r, -r), (r, r), (-r, r)]
+    if shape == "triangle-up":
+        return [(0, -1.2 * r), (1.1 * r, 0.85 * r), (-1.1 * r, 0.85 * r)]
+    if shape == "triangle-down":
+        return [(0, 1.2 * r), (1.1 * r, -0.85 * r), (-1.1 * r, -0.85 * r)]
+    if shape == "diamond":
+        return [(0, -1.3 * r), (1.3 * r, 0), (0, 1.3 * r), (-1.3 * r, 0)]
+    if shape == "plus":
+        t = 0.45 * r
+        return [(-t, -r), (t, -r), (t, -t), (r, -t), (r, t), (t, t), (t, r), (-t, r), (-t, t), (-r, t), (-r, -t), (-t, -t)]
+    if shape == "cross":
+        c = np.sqrt(2.0) / 2.0
+        return [(c * (x - y), c * (x + y)) for x, y in _marker_points("plus", r)]
+    if shape == "pentagon":
+        return [(1.2 * r * np.sin(2 * np.pi * k / 5), -1.2 * r * np.cos(2 * np.pi * k / 5)) for k in range(5)]
+    if shape == "star":
+        return [
+            (radius * np.sin(np.pi * k / 5), -radius * np.cos(np.pi * k / 5))
+            for k, radius in ((k, 1.5 * r if k % 2 == 0 else 0.65 * r) for k in range(10))
+        ]
+    raise ValueError(f"Unknown marker shape '{shape}'.")
+
+
+def _svg_marker(shape: str, x: float, y: float, r: float, color: str, extra: str = "") -> str:
+    points = " ".join(f"{x + dx:.1f},{y + dy:.1f}" for dx, dy in _marker_points(shape, r))
+    return f'<polygon class="mk" points="{points}" fill="{color}" {extra}/>'
+
+
+def _tip(title: str, port_lines: list[tuple[str, int]], feature_lines: dict[str, float]) -> str:
+    """Build the tooltip HTML for one object and escape it for use in an attribute."""
+    parts = [f"<b>{html.escape(title)}</b>"]
+    parts += [f"{html.escape(pn)} &rarr; {addr}" for pn, addr in port_lines]
+    parts += [f"{html.escape(fn)} = {value:.5g}" for fn, value in feature_lines.items()]
+    return html.escape("<br>".join(parts), quote=True)
+
+
+def plot_graph_interactive(
+    graph: Graph,
+    *,
+    iterations: int = 150,
+    seed: int = 0,
+    size: int = 640,
+    theme: str = "auto",
+) -> InteractiveGraphPlot:
+    """
+    Render a single Graph as a self-contained interactive HTML/SVG figure.
+
+    Address indices are always visible; hovering any object (address, hyper-edge
+    marker or line) shows a tooltip with its port addresses and feature values, and
+    reveals the port names along its connections. The result displays inline in
+    Jupyter/IDE notebooks (via ``_repr_html_``) and can be written to a standalone
+    HTML file with :meth:`InteractiveGraphPlot.save`. No dependency is required.
+
+    :param graph: A single Graph; batched graphs must first go through
+        :func:`energnn.graph.separate_graphs`.
+    :param iterations: Number of layout relaxation steps.
+    :param seed: Seed for the layout's random initial positions.
+    :param size: Width and height of the drawing, in pixels.
+    :param theme: ``"light"``, ``"dark"``, or ``"auto"`` to follow the viewer's
+        color-scheme preference via CSS.
+    :return: An :class:`InteractiveGraphPlot`.
+    :raises ValueError: If the graph is not single, or if ``theme`` is invalid.
+    """
+    if theme not in ("light", "dark", "auto"):
+        raise ValueError("theme must be 'light', 'dark' or 'auto'.")
+
+    data = _extract_plot_data(graph, iterations=iterations, seed=seed)
+    n_addr, pos = data.n_addr, data.pos
+
+    pad = 30.0
+    xy = (pos + 1.0) / 2.0 * (size - 2 * pad) + pad
+    r_addr = float(np.clip(150.0 / np.sqrt(max(n_addr, 1)), 5.0, 13.0))
+    r_mark = 0.62 * r_addr
+    stroke = float(np.clip(r_addr / 6.0, 1.0, 2.0))
+    uid = f"energnn-plot-{next(_plot_ids)}"
+
+    light, dark = _THEMES["light"], _THEMES["dark"]
+
+    def _vars(t: _Theme) -> str:
+        slots = "".join(f"--c{i}:{c};" for i, c in enumerate(t.palette))
+        return f"--surface:{t.surface};--ink:{t.ink};{slots}"
+
+    if theme == "auto":
+        theme_css = f"#{uid}{{{_vars(light)}}}" f"@media (prefers-color-scheme: dark){{#{uid}{{{_vars(dark)}}}}}"
+    else:
+        theme_css = f"#{uid}{{{_vars(_THEMES[theme])}}}"
+
+    css = (
+        f"{theme_css}"
+        f"#{uid}{{position:relative;display:inline-block;font-family:system-ui,sans-serif;"
+        f"background:var(--surface);border-radius:6px}}"
+        f"#{uid} .lg{{display:flex;flex-wrap:wrap;gap:4px 14px;padding:8px 12px 0;color:var(--ink);font-size:12px}}"
+        f"#{uid} .lg span{{display:inline-flex;align-items:center;gap:5px}}"
+        f"#{uid} .obj .pl{{opacity:0;fill:var(--ink);font-size:9px;pointer-events:none}}"
+        f"#{uid} .obj:hover .pl{{opacity:1}}"
+        f"#{uid} .obj:hover line{{stroke-width:{2.2 * stroke:.1f}px}}"
+        f"#{uid} .obj:hover .mk,#{uid} .addr:hover circle{{stroke:var(--ink);stroke-width:1.5px}}"
+        f"#{uid} .tip{{display:none;position:absolute;pointer-events:none;background:var(--surface);color:var(--ink);"
+        f"border:1px solid {_ADDRESS_COLOR};border-radius:4px;padding:5px 8px;font-size:11px;line-height:1.5;"
+        f"white-space:nowrap;z-index:10}}"
+    )
+
+    svg: list[str] = []
+    legend: list[str] = [
+        f'<span><svg width="14" height="14"><circle cx="7" cy="7" r="5" fill="{_ADDRESS_COLOR}"/></svg>addresses</span>'
+    ]
+
+    for class_index, name in enumerate(data.classes):
+        color_var = f"var(--c{class_index % len(light.palette)})"
+        shape = _SVG_MARKERS[class_index % len(_SVG_MARKERS)]
+        legend.append(
+            f'<span><svg width="14" height="14">{_svg_marker(shape, 7, 7, 4.5, color_var)}</svg>{html.escape(name)}</span>'
+        )
+        port_names = data.port_names[name]
+        for i, edge_ports in enumerate(data.ports[name]):
+            tip = _tip(f"{name} #{i}", list(zip(port_names, edge_ports)), data.features[name][i])
+            body: list[str] = []
+
+            def _spoke(a: np.ndarray, b: np.ndarray, label: str, frac: float = 0.5) -> None:
+                body.append(
+                    f'<line x1="{a[0]:.1f}" y1="{a[1]:.1f}" x2="{b[0]:.1f}" y2="{b[1]:.1f}"'
+                    f' stroke="{color_var}" stroke-width="{stroke:.1f}" stroke-opacity="0.85"/>'
+                )
+                at = a + frac * (b - a)
+                body.append(
+                    f'<text class="pl" x="{at[0]:.1f}" y="{at[1] - 3:.1f}" text-anchor="middle">{html.escape(label)}</text>'
+                )
+
+            if len(edge_ports) == 1:
+                angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
+                point = xy[edge_ports[0]] + 2.2 * r_addr * np.array([np.cos(angle), np.sin(angle)])
+                _spoke(xy[edge_ports[0]], point, port_names[0], frac=0.55)
+            elif len(edge_ports) == 2:
+                a, b = xy[edge_ports[0]], xy[edge_ports[1]]
+                _spoke(a, b, port_names[0], frac=0.25)
+                body.append(
+                    f'<text class="pl" x="{(b + 0.25 * (a - b))[0]:.1f}" y="{(b + 0.25 * (a - b))[1] - 3:.1f}"'
+                    f' text-anchor="middle">{html.escape(port_names[1])}</text>'
+                )
+                point = (a + b) / 2.0
+            elif len(edge_ports) >= 3:
+                point = xy[data.hub_ids[(name, i)]]
+                for port_index, p in enumerate(edge_ports):
+                    _spoke(point, xy[p], port_names[port_index])
+            else:
+                continue
+            body.append(_svg_marker(shape, point[0], point[1], r_mark, color_var, 'stroke="var(--surface)" stroke-width="1"'))
+            svg.append(f'<g class="obj" data-tip="{tip}">{"".join(body)}</g>')
+
+    for i in range(n_addr):
+        label = (
+            f'<text x="{xy[i][0]:.1f}" y="{xy[i][1]:.1f}" text-anchor="middle" dominant-baseline="central"'
+            f' fill="#ffffff" font-size="{max(round(0.95 * r_addr), 7)}" pointer-events="none">{i}</text>'
+        )
+        svg.append(
+            f'<g class="addr" data-tip="{_tip(f"address {i}", [], {})}">'
+            f'<circle cx="{xy[i][0]:.1f}" cy="{xy[i][1]:.1f}" r="{r_addr:.1f}" fill="{_ADDRESS_COLOR}"/>{label}</g>'
+        )
+
+    script = (
+        f"(function(){{var root=document.getElementById('{uid}');var tip=root.querySelector('.tip');"
+        f"root.querySelectorAll('[data-tip]').forEach(function(el){{"
+        f"el.addEventListener('mousemove',function(e){{tip.innerHTML=el.getAttribute('data-tip');"
+        f"tip.style.display='block';var r=root.getBoundingClientRect();"
+        f"tip.style.left=(e.clientX-r.left+14)+'px';tip.style.top=(e.clientY-r.top+14)+'px';}});"
+        f"el.addEventListener('mouseleave',function(){{tip.style.display='none';}});}});}})();"
+    )
+
+    fragment = (
+        f"<style>{css}</style>"
+        f'<div id="{uid}"><div class="lg">{"".join(legend)}</div>'
+        f'<svg width="{size}" height="{size}" viewBox="0 0 {size} {size}">{"".join(svg)}</svg>'
+        f'<div class="tip"></div><script>{script}</script></div>'
+    )
+    return InteractiveGraphPlot(fragment)

--- a/src/energnn/graph/plot.py
+++ b/src/energnn/graph/plot.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from energnn.graph.graph import Graph
+
+# Colorblind-validated categorical palette; slot order is part of the validation.
+_PALETTE = ["#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4", "#008300", "#4a3aa7", "#e34948"]
+# Marker shapes double the color encoding so classes stay separable without color.
+_MARKERS = ["s", "^", "D", "v", "P", "X", "p", "*"]
+_ADDRESS_COLOR = "#898781"
+_SURFACE = "#fcfcfb"
+_INK = "#0b0b0b"
+
+
+def spring_layout(n_nodes: int, edges: np.ndarray, *, iterations: int = 150, seed: int = 0) -> np.ndarray:
+    """
+    Compute a Fruchterman-Reingold force-directed layout.
+
+    :param n_nodes: Number of nodes to place.
+    :param edges: Integer array of shape ``(n_edges, 2)`` listing node pairs.
+    :param iterations: Number of relaxation steps.
+    :param seed: Seed for the random initial positions.
+    :return: Positions array of shape ``(n_nodes, 2)`` scaled to ``[-1, 1]``.
+    """
+    rng = np.random.default_rng(seed)
+    pos = rng.uniform(-1.0, 1.0, size=(n_nodes, 2))
+    if n_nodes <= 1:
+        return pos
+    k = 1.0 / np.sqrt(n_nodes)
+    temperature = 0.1
+    cooling = temperature / (iterations + 1)
+    adjacency = np.zeros((n_nodes, n_nodes), dtype=bool)
+    if len(edges):
+        adjacency[edges[:, 0], edges[:, 1]] = True
+        adjacency[edges[:, 1], edges[:, 0]] = True
+    for _ in range(iterations):
+        delta = pos[:, None, :] - pos[None, :, :]
+        dist = np.linalg.norm(delta, axis=-1)
+        np.fill_diagonal(dist, 1.0)
+        dist = np.maximum(dist, 0.01)
+        force = k * k / dist**2 - adjacency * dist / k
+        displacement = (delta * force[..., None]).sum(axis=1)
+        length = np.maximum(np.linalg.norm(displacement, axis=-1, keepdims=True), 1e-9)
+        pos += displacement / length * np.minimum(length, temperature)
+        temperature -= cooling
+    pos -= pos.mean(axis=0)
+    scale = np.abs(pos).max()
+    return pos / scale if scale > 0 else pos
+
+
+def plot_graph(
+    graph: Graph,
+    *,
+    ax: Axes | None = None,
+    address_labels: bool = False,
+    iterations: int = 150,
+    seed: int = 0,
+    node_size: float | None = None,
+) -> Axes:
+    """
+    Plot a single (non-batched) Graph with one color and marker per hyper-edge class.
+
+    Addresses are drawn as gray circles. Hyper-edges of order 1 are drawn as a small
+    marker attached to their address, hyper-edges of order 2 as a line between their
+    two addresses with a marker at midpoint, and hyper-edges of order 3 or more as a
+    hub marker connected to all their ports. Fictitious (padded) objects and
+    addresses are skipped.
+
+    Requires ``matplotlib``.
+
+    :param graph: A single Graph; batched graphs must first go through
+        :func:`energnn.graph.separate_graphs`.
+    :param ax: Axes to draw into; a new figure is created when None.
+    :param address_labels: If True, write the address index on each address node.
+    :param iterations: Number of layout relaxation steps.
+    :param seed: Seed for the layout's random initial positions.
+    :param node_size: Address marker area; inferred from the number of addresses when None.
+    :return: The matplotlib Axes containing the plot.
+    :raises ImportError: If matplotlib is not installed.
+    :raises ValueError: If the graph is not single.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError("plot_graph requires matplotlib; install it with 'pip install matplotlib'.") from exc
+
+    if not graph.is_single:
+        raise ValueError("plot_graph only handles single graphs; use separate_graphs() on a batch first.")
+
+    g = graph.to_numpy_backend()
+    n_addr = int(np.asarray(g.non_fictitious_addresses).sum())
+    if node_size is None:
+        node_size = float(np.clip(4000.0 / max(n_addr, 1), 12.0, 130.0))
+    line_width = float(np.clip(1.4 * np.sqrt(node_size / 130.0), 0.7, 1.4))
+
+    # Collect the port lists of real (non-fictitious) hyper-edges, per class.
+    classes = sorted(g.hyper_edge_sets)
+    edges_by_class: dict[str, list[list[int]]] = {}
+    for name in classes:
+        hes = g.hyper_edge_sets[name]
+        mask = np.asarray(hes.non_fictitious) > 0
+        if hes.port_dict is None:
+            edges_by_class[name] = []
+            continue
+        ports = np.stack([np.asarray(hes.port_dict[k]) for k in sorted(hes.port_dict)], axis=-1)
+        edges_by_class[name] = [list(map(int, row)) for row in ports[mask]]
+
+    # Star expansion for the layout: addresses in [0, n_addr), then one hub per order>=3 edge.
+    layout_edges: list[tuple[int, int]] = []
+    hub_ids: dict[tuple[str, int], int] = {}
+    next_id = n_addr
+    for name in classes:
+        for i, edge_ports in enumerate(edges_by_class[name]):
+            if len(edge_ports) == 2:
+                layout_edges.append((edge_ports[0], edge_ports[1]))
+            elif len(edge_ports) >= 3:
+                hub_ids[(name, i)] = next_id
+                layout_edges.extend((next_id, p) for p in edge_ports)
+                next_id += 1
+    pos = spring_layout(next_id, np.array(layout_edges, dtype=int).reshape(-1, 2), iterations=iterations, seed=seed)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(7, 7))
+    ax.set_facecolor(_SURFACE)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+    for class_index, name in enumerate(classes):
+        color = _PALETTE[class_index % len(_PALETTE)]
+        segments_x: list[Any] = []
+        segments_y: list[Any] = []
+        for i, edge_ports in enumerate(edges_by_class[name]):
+            if len(edge_ports) == 2:
+                a, b = pos[edge_ports[0]], pos[edge_ports[1]]
+                segments_x += [a[0], b[0], None]
+                segments_y += [a[1], b[1], None]
+            elif len(edge_ports) >= 3:
+                hub = pos[hub_ids[(name, i)]]
+                for p in edge_ports:
+                    segments_x += [hub[0], pos[p][0], None]
+                    segments_y += [hub[1], pos[p][1], None]
+        if segments_x:
+            ax.plot(segments_x, segments_y, color=color, linewidth=line_width, alpha=0.85, zorder=1)
+
+    ax.scatter(
+        pos[:n_addr, 0],
+        pos[:n_addr, 1],
+        s=node_size,
+        c=_ADDRESS_COLOR,
+        edgecolors=_SURFACE,
+        linewidths=1.5,
+        zorder=3,
+        label="addresses",
+    )
+    if address_labels:
+        for i in range(n_addr):
+            ax.annotate(str(i), pos[i], ha="center", va="center", fontsize=7, color="#ffffff", zorder=4)
+
+    for class_index, name in enumerate(classes):
+        color = _PALETTE[class_index % len(_PALETTE)]
+        marker = _MARKERS[class_index % len(_MARKERS)]
+        xs, ys = [], []
+        for i, edge_ports in enumerate(edges_by_class[name]):
+            if len(edge_ports) == 1:
+                # Deterministic radial offset so several order-1 edges on one address stay visible.
+                angle = 2.0 * np.pi * ((class_index * 0.37 + i * 0.61) % 1.0)
+                point = pos[edge_ports[0]] + 0.045 * np.array([np.cos(angle), np.sin(angle)])
+            elif len(edge_ports) == 2:
+                point = (pos[edge_ports[0]] + pos[edge_ports[1]]) / 2.0
+            elif len(edge_ports) >= 3:
+                point = pos[hub_ids[(name, i)]]
+            else:
+                continue
+            xs.append(point[0])
+            ys.append(point[1])
+        if xs:
+            ax.scatter(
+                xs, ys, s=0.45 * node_size, c=color, marker=marker, edgecolors=_SURFACE, linewidths=0.8, zorder=3.5, label=name
+            )
+
+    ax.legend(loc="upper left", bbox_to_anchor=(1.0, 1.0), frameon=False, labelcolor=_INK, fontsize=9)
+    return ax

--- a/tests/graph/test_plot.py
+++ b/tests/graph/test_plot.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from energnn.graph.graph import Graph, collate_graphs  # noqa: E402
+from energnn.graph.hyper_edge_set import HyperEdgeSet  # noqa: E402
+from energnn.graph.plot import plot_graph, spring_layout  # noqa: E402
+from energnn.graph.shape import GraphShape  # noqa: E402
+
+
+@pytest.fixture
+def mixed_order_graph() -> Graph:
+    hes = {
+        "line": HyperEdgeSet.from_dict(
+            port_dict={"from": np.array([0, 1, 2]), "to": np.array([1, 2, 3])},
+            feature_dict={"x": np.array([0.1, 0.2, 0.3])},
+        ),
+        "gen": HyperEdgeSet.from_dict(
+            port_dict={"bus": np.array([0, 3])},
+            feature_dict={"p": np.array([1.0, 2.0])},
+        ),
+        "trafo3w": HyperEdgeSet.from_dict(
+            port_dict={"hv": np.array([0]), "mv": np.array([1]), "lv": np.array([2])},
+            feature_dict={"ratio": np.array([1.02])},
+        ),
+    }
+    return Graph.from_dict(hyper_edge_set_dict=hes, n_addresses=4)
+
+
+def teardown_function() -> None:
+    plt.close("all")
+
+
+def test_spring_layout_shape_and_scale():
+    pos = spring_layout(5, np.array([[0, 1], [1, 2], [2, 3], [3, 4]]))
+    assert pos.shape == (5, 2)
+    assert np.abs(pos).max() <= 1.0 + 1e-6
+
+
+def test_spring_layout_no_edges():
+    pos = spring_layout(3, np.zeros((0, 2), dtype=int))
+    assert pos.shape == (3, 2)
+
+
+def test_plot_graph_returns_axes(mixed_order_graph):
+    ax = plot_graph(mixed_order_graph)
+    # one gray collection for addresses + one per hyper-edge class
+    assert len(ax.collections) == 1 + len(mixed_order_graph.hyper_edge_sets)
+    labels = [artist.get_label() for artist in ax.collections]
+    assert labels == ["addresses", "gen", "line", "trafo3w"]
+
+
+def test_plot_graph_into_existing_axes(mixed_order_graph):
+    _, ax = plt.subplots()
+    assert plot_graph(mixed_order_graph, ax=ax) is ax
+
+
+def test_plot_graph_skips_fictitious(mixed_order_graph):
+    ax_ref = plot_graph(mixed_order_graph)
+    n_points_ref = [len(c.get_offsets()) for c in ax_ref.collections]
+
+    target = GraphShape(
+        hyper_edge_sets={"line": np.array(6), "gen": np.array(5), "trafo3w": np.array(2)},
+        addresses=np.array(7),
+    )
+    mixed_order_graph.pad(target)
+    ax_padded = plot_graph(mixed_order_graph)
+    n_points_padded = [len(c.get_offsets()) for c in ax_padded.collections]
+    assert n_points_padded == n_points_ref
+
+
+def test_plot_graph_rejects_batch(mixed_order_graph):
+    batch = collate_graphs([mixed_order_graph, mixed_order_graph])
+    with pytest.raises(ValueError, match="single"):
+        plot_graph(batch)

--- a/tests/graph/test_plot.py
+++ b/tests/graph/test_plot.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 
 from energnn.graph.graph import Graph, collate_graphs  # noqa: E402
 from energnn.graph.hyper_edge_set import HyperEdgeSet  # noqa: E402
-from energnn.graph.plot import plot_graph, spring_layout  # noqa: E402
+from energnn.graph.plot import InteractiveGraphPlot, plot_graph, plot_graph_interactive, spring_layout  # noqa: E402
 from energnn.graph.shape import GraphShape  # noqa: E402
 
 
@@ -99,3 +99,47 @@ def test_plot_graph_auto_theme_follows_rcparams(mixed_order_graph):
 def test_plot_graph_invalid_theme(mixed_order_graph):
     with pytest.raises(ValueError, match="theme"):
         plot_graph(mixed_order_graph, theme="solarized")
+
+
+def test_plot_graph_port_labels(mixed_order_graph):
+    ax = plot_graph(mixed_order_graph, port_labels=True)
+    texts = {t.get_text() for t in ax.texts}
+    assert {"from", "to", "bus", "hv", "mv", "lv"} <= texts
+
+
+def test_interactive_plot_content(mixed_order_graph):
+    plot = plot_graph_interactive(mixed_order_graph)
+    assert isinstance(plot, InteractiveGraphPlot)
+    fragment = plot._repr_html_()
+    # class names in the legend, address ids, port names, and feature values in tooltips
+    for expected in ["line", "gen", "trafo3w", ">3</text>", "hv", "mv", "lv", "1.02", "address 0"]:
+        assert expected in fragment
+    assert fragment.count('class="addr"') == 4
+    # one group per real hyper-edge: 3 lines + 2 gens + 1 trafo3w
+    assert fragment.count('class="obj"') == 6
+
+
+def test_interactive_plot_skips_fictitious(mixed_order_graph):
+    target = GraphShape(
+        hyper_edge_sets={"line": np.array(6), "gen": np.array(5), "trafo3w": np.array(2)},
+        addresses=np.array(7),
+    )
+    mixed_order_graph.pad(target)
+    fragment = plot_graph_interactive(mixed_order_graph)._repr_html_()
+    assert fragment.count('class="addr"') == 4
+    assert fragment.count('class="obj"') == 6
+
+
+def test_interactive_plot_rejects_batch(mixed_order_graph):
+    batch = collate_graphs([mixed_order_graph, mixed_order_graph])
+    with pytest.raises(ValueError, match="single"):
+        plot_graph_interactive(batch)
+
+
+def test_interactive_plot_save(mixed_order_graph, tmp_path):
+    path = str(tmp_path / "graph.html")
+    plot_graph_interactive(mixed_order_graph).save(path)
+    with open(path, encoding="utf-8") as handle:
+        content = handle.read()
+    assert content.startswith("<!DOCTYPE html>")
+    assert "trafo3w" in content

--- a/tests/graph/test_plot.py
+++ b/tests/graph/test_plot.py
@@ -82,3 +82,20 @@ def test_plot_graph_rejects_batch(mixed_order_graph):
     batch = collate_graphs([mixed_order_graph, mixed_order_graph])
     with pytest.raises(ValueError, match="single"):
         plot_graph(batch)
+
+
+def test_plot_graph_dark_theme(mixed_order_graph):
+    ax = plot_graph(mixed_order_graph, theme="dark")
+    assert ax.get_facecolor() == matplotlib.colors.to_rgba("#1a1a19")
+    assert ax.figure.get_facecolor() == matplotlib.colors.to_rgba("#1a1a19")
+
+
+def test_plot_graph_auto_theme_follows_rcparams(mixed_order_graph):
+    with matplotlib.rc_context({"figure.facecolor": "#2b2b2b"}):
+        ax = plot_graph(mixed_order_graph)
+    assert ax.get_facecolor() == matplotlib.colors.to_rgba("#1a1a19")
+
+
+def test_plot_graph_invalid_theme(mixed_order_graph):
+    with pytest.raises(ValueError, match="theme"):
+        plot_graph(mixed_order_graph, theme="solarized")

--- a/tests/graph/test_plot.py
+++ b/tests/graph/test_plot.py
@@ -136,6 +136,73 @@ def test_interactive_plot_rejects_batch(mixed_order_graph):
         plot_graph_interactive(batch)
 
 
+@pytest.fixture
+def multi_graph() -> Graph:
+    """3 parallel lines 0-1, a self-loop on 2, and 2 parallel 3-port trafos."""
+    hes = {
+        "line": HyperEdgeSet.from_dict(
+            port_dict={"from": np.array([0, 0, 0, 2]), "to": np.array([1, 1, 1, 2])},
+            feature_dict={"x": np.array([0.1, 0.2, 0.3, 0.4])},
+        ),
+        "trafo3w": HyperEdgeSet.from_dict(
+            port_dict={"hv": np.array([0, 0]), "mv": np.array([1, 1]), "lv": np.array([2, 2])},
+            feature_dict={"ratio": np.array([1.0, 1.1])},
+        ),
+    }
+    return Graph.from_dict(hyper_edge_set_dict=hes, n_addresses=3)
+
+
+def test_parallel_edges_have_distinct_markers(multi_graph):
+    ax = plot_graph(multi_graph)
+    line_collection = next(c for c in ax.collections if c.get_label() == "line")
+    offsets = np.asarray(line_collection.get_offsets())
+    assert len(np.unique(np.round(offsets, 6), axis=0)) == 4
+
+
+def test_self_loop_is_visible(multi_graph):
+    ax = plot_graph(multi_graph)
+    line_collection = next(c for c in ax.collections if c.get_label() == "line")
+    loop_marker = np.asarray(line_collection.get_offsets())[3]
+    address_positions = np.asarray(next(c for c in ax.collections if c.get_label() == "addresses").get_offsets())
+    assert np.linalg.norm(address_positions - loop_marker, axis=1).min() > 0.05
+
+
+def test_parallel_hubs_are_separated(multi_graph):
+    ax = plot_graph(multi_graph)
+    trafo_offsets = np.asarray(next(c for c in ax.collections if c.get_label() == "trafo3w").get_offsets())
+    assert np.linalg.norm(trafo_offsets[0] - trafo_offsets[1]) > 0.01
+
+
+def test_interactive_multi_graph(multi_graph):
+    fragment = plot_graph_interactive(multi_graph)._repr_html_()
+    assert fragment.count('class="obj"') == 6
+
+
+def test_injected_positions(mixed_order_graph):
+    positions = np.array([[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]])
+    ax = plot_graph(mixed_order_graph, positions=positions)
+    drawn = np.asarray(next(c for c in ax.collections if c.get_label() == "addresses").get_offsets())
+    # normalized to [-1, 1] but the square must be preserved
+    expected = np.array([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])
+    np.testing.assert_allclose(drawn, expected, atol=1e-6)
+
+
+def test_injected_positions_padded_length(mixed_order_graph):
+    target = GraphShape(
+        hyper_edge_sets={"line": np.array(6), "gen": np.array(5), "trafo3w": np.array(2)},
+        addresses=np.array(7),
+    )
+    mixed_order_graph.pad(target)
+    positions = np.arange(14, dtype=float).reshape(7, 2)  # padded length: extra rows dropped
+    fragment = plot_graph_interactive(mixed_order_graph, positions=positions)._repr_html_()
+    assert fragment.count('class="addr"') == 4
+
+
+def test_injected_positions_bad_shape(mixed_order_graph):
+    with pytest.raises(ValueError, match="positions"):
+        plot_graph(mixed_order_graph, positions=np.zeros((3, 2)))
+
+
 def test_interactive_plot_save(mixed_order_graph, tmp_path):
     path = str(tmp_path / "graph.html")
     plot_graph_interactive(mixed_order_graph).save(path)


### PR DESCRIPTION
## Summary

Adds quick visualization of a `Graph` (H2MG), with no new dependency:

- **`plot_graph`** (matplotlib): addresses as gray circles with their index, one color + marker shape per hyper-edge class (colorblind-validated palette), automatic legend. Order-1 hyper-edges attach to their address, order-2 draw as lines with a midpoint marker, order ≥ 3 as a hub connected to its ports. Optional `port_labels`.
- **`plot_graph_interactive`**: self-contained HTML/SVG figure displayed inline by notebooks (`_repr_html_`) — hover any object for a tooltip with its port addresses and feature values (port names appear along the connections), wheel zoom, drag pan, double-click reset. `InteractiveGraphPlot.save()` writes a standalone HTML page.

Both front-ends share the data extraction and layout:

- pure-numpy Fruchterman–Reingold layout (no networkx), or **injected address coordinates** via `positions` (e.g. latent coordinates from a coupler); hubs then sit at the barycenter of their ports;
- **multi-graph support**: parallel order-2 edges fan out as symmetric Bezier curves, self-loops draw as small circles attached to their address;
- fictitious (padded) objects and addresses are skipped; batched graphs raise with a pointer to `separate_graphs`;
- light/dark theming: `theme="auto"` follows matplotlib's figure facecolor (matplotlib front-end) or the CSS `prefers-color-scheme` (HTML front-end).

The tutorial notebook gains a *Graph Visualization* section with a runnable multi-graph example.

## Test plan

- [x] 22 new tests in `tests/graph/test_plot.py` (layout, both front-ends, padding, multi-graph separation, injected positions, themes)
- [x] full `tests/graph` suite: 140 passed (CPU)
- [x] black / flake8 / mypy clean
- [x] visual check of matplotlib output and of the HTML figure (headless Firefox screenshots), light and dark
- [ ] check hover/zoom behavior in a PyCharm notebook (WIP: needs manual confirmation in the IDE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)