### PR TITLE
Prettier pandas-free printing for Graph, HyperEdgeSet and GraphStructure

### DIFF
--- a/src/energnn/graph/formatting.py
+++ b/src/energnn/graph/formatting.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Lightweight text-table rendering used by ``Graph``/``HyperEdgeSet`` printing."""
+
+from __future__ import annotations
+
+MAX_ROWS = 30
+ELLIPSIS = "⋯"
+
+Column = tuple[str, list[str]]
+Group = tuple[str, list[Column]]
+
+
+def format_int_column(values) -> list[str]:
+    return [str(int(v)) for v in values]
+
+
+def format_float_column(values) -> list[str]:
+    return [f"{float(v):.6g}" for v in values]
+
+
+def select_rows(n_rows: int, max_rows: int = MAX_ROWS) -> tuple[list[int], int | None]:
+    """Pick the row indices to display.
+
+    Returns the indices and, when truncated, the position at which an ellipsis
+    row must be inserted (``None`` otherwise).
+    """
+    if n_rows <= max_rows:
+        return list(range(n_rows)), None
+    head = (max_rows + 1) // 2
+    tail = max_rows - head
+    return list(range(head)) + list(range(n_rows - tail, n_rows)), head
+
+
+def render_grouped_table(
+    index_columns: list[Column],
+    groups: list[Group],
+    ellipsis_at: int | None = None,
+) -> list[str]:
+    """Render right-aligned columns grouped in blocks separated by ``│``.
+
+    ``index_columns`` forms an unnamed leading block; each entry of ``groups``
+    is a ``(group_name, columns)`` block whose name is centered above it.
+    """
+    blocks = [("", index_columns)] + [g for g in groups if g[1]]
+    blocks = [b for b in blocks if b[1]]
+    if not blocks:
+        return []
+
+    specs = []
+    for group_name, columns in blocks:
+        widths = [max(len(name), max((len(c) for c in cells), default=0)) for name, cells in columns]
+        content = sum(widths) + 2 * (len(columns) - 1)
+        if len(group_name) > content:
+            widths[0] += len(group_name) - content
+            content = len(group_name)
+        specs.append((group_name, columns, widths, content))
+
+    lines = []
+    if any(name for name, *_ in specs):
+        lines.append(" │ ".join(name.center(content) for name, _, _, content in specs).rstrip())
+    lines.append(
+        " │ ".join(
+            "  ".join(name.rjust(w) for (name, _), w in zip(columns, widths)) for _, columns, widths, _ in specs
+        ).rstrip()
+    )
+    lines.append("─┼─".join("─" * content for *_, content in specs))
+
+    n_rows = len(specs[0][1][0][1])
+    for r in range(n_rows):
+        if r == ellipsis_at:
+            lines.append(" │ ".join(ELLIPSIS.center(content) for *_, content in specs).rstrip())
+        lines.append(
+            " │ ".join(
+                "  ".join(cells[r].rjust(w) for (_, cells), w in zip(columns, widths)) for _, columns, widths, _ in specs
+            ).rstrip()
+        )
+    return lines

--- a/src/energnn/graph/graph.py
+++ b/src/energnn/graph/graph.py
@@ -190,7 +190,26 @@ class Graph(dict):
         self[HYPER_EDGE_SETS] = hyper_edge_set_dict
 
     def __str__(self) -> str:
-        return "".join("{}\n{}\n".format(k, v) for k, v in sorted(self.hyper_edge_sets.items()))
+        sets = sorted(self.hyper_edge_sets.items()) if self.hyper_edge_sets is not None else []
+
+        header_parts = [f"{len(sets)} hyper-edge set{'s' if len(sets) != 1 else ''}"]
+        if sets and self.is_batch:
+            header_parts.insert(0, f"batch of {sets[0][1].n_batch}")
+        if self.true_shape is not None:
+            addresses = np.unique(np.asarray(self.true_shape.addresses).reshape(-1))
+            if addresses.size == 1:
+                header_parts.append(f"{int(addresses[0])} addresses")
+            elif addresses.size > 1:
+                header_parts.append(f"{int(addresses.min())}–{int(addresses.max())} addresses")
+        lines = ["Graph · " + " · ".join(header_parts)]
+
+        for i, (name, hyper_edge_set) in enumerate(sets):
+            last = i == len(sets) - 1
+            branch, continuation = ("└─ ", "   ") if last else ("├─ ", "│  ")
+            lines.append("│")
+            lines.append(f"{branch}{name} · {hyper_edge_set._summary()}")
+            lines.extend(continuation + line for line in hyper_edge_set._table_lines())
+        return "\n".join(lines)
 
     # ------------------------------------------------------------------
     # Batch detection

--- a/src/energnn/graph/hyper_edge_set.py
+++ b/src/energnn/graph/hyper_edge_set.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 import numpy as np
-import pandas as pd
 from jax.tree_util import register_pytree_node_class
 
 from energnn.graph.backend import PRESERVE_DTYPE, Backend, NumpyBackend
+from energnn.graph.formatting import format_float_column, format_int_column, render_grouped_table, select_rows
 from energnn.graph.utils import to_numpy
 
 FEATURE_ARRAY = "feature_array"
@@ -182,26 +182,58 @@ class HyperEdgeSet(dict):
     # String representation
     # ------------------------------------------------------------------
 
-    def __str__(self) -> str:
+    def _summary(self) -> str:
+        """One-line description: object, port and feature counts."""
+        parts = []
+        if self.is_batch:
+            parts.append(f"batch of {self.n_batch}")
+        n_obj = self.n_obj
+        obj_part = f"{n_obj} object{'s' if n_obj != 1 else ''}"
+        if self.non_fictitious is not None:
+            n_real = int(np.asarray(self.non_fictitious).sum())
+            n_total = int(np.asarray(self.non_fictitious).size)
+            if n_real != n_total and not self.is_batch:
+                obj_part += f" ({n_real} real)"
+        parts.append(obj_part)
+        n_ports = len(self.port_dict) if self.port_dict is not None else 0
+        parts.append(f"{n_ports} port{'s' if n_ports != 1 else ''}")
+        n_feat = len(self.feature_names) if self.feature_names is not None else 0
+        parts.append(f"{n_feat} feature{'s' if n_feat != 1 else ''}")
+        return " · ".join(parts)
+
+    def _table_lines(self) -> list[str]:
+        """Render ports and features as an aligned text table (no pandas)."""
         if self.is_single:
-            index = pd.MultiIndex.from_product([range(self.n_obj)], names=["object_id"])
+            n_rows = self.n_obj
+            index_values = [("", [str(i) for i in range(n_rows)])]
         elif self.is_batch:
-            index = pd.MultiIndex.from_product(
-                [range(self.n_batch), range(self.n_obj)],
-                names=["batch_id", "object_id"],
-            )
+            n_rows = self.n_batch * self.n_obj
+            index_values = [
+                ("batch", [str(b) for b in range(self.n_batch) for _ in range(self.n_obj)]),
+                ("obj", [str(i) for _ in range(self.n_batch) for i in range(self.n_obj)]),
+            ]
         else:
             raise ValueError("HyperEdgeSet is neither single nor batched.")
 
-        d: dict = {}
-        if self.port_names is not None:
-            for k, v in sorted(self.port_dict.items()):
-                d[("ports", k)] = np.array(v.reshape([-1]))
-        if self.feature_names is not None:
-            for k, v in sorted(self.feature_dict.items()):
-                d[("features", k)] = np.array(v.reshape([-1]))
+        rows, ellipsis_at = select_rows(n_rows)
 
-        return pd.DataFrame(d, index=index).__str__()
+        def take(cells: list[str]) -> list[str]:
+            return [cells[r] for r in rows]
+
+        index_columns = [(name, take(cells)) for name, cells in index_values]
+
+        groups = []
+        if self.port_dict is not None:
+            columns = [(k, take(format_int_column(np.asarray(v).reshape(-1)))) for k, v in sorted(self.port_dict.items())]
+            groups.append(("ports", columns))
+        if self.feature_names is not None:
+            columns = [(k, take(format_float_column(np.asarray(v).reshape(-1)))) for k, v in sorted(self.feature_dict.items())]
+            groups.append(("features", columns))
+
+        return render_grouped_table(index_columns, groups, ellipsis_at=ellipsis_at)
+
+    def __str__(self) -> str:
+        return "\n".join([f"HyperEdgeSet · {self._summary()}", *self._table_lines()])
 
     # ------------------------------------------------------------------
     # Core array properties

--- a/src/energnn/graph/hyper_edge_set.py
+++ b/src/energnn/graph/hyper_edge_set.py
@@ -215,6 +215,13 @@ class HyperEdgeSet(dict):
         else:
             raise ValueError("HyperEdgeSet is neither single nor batched.")
 
+        has_fictitious = False
+        if self.non_fictitious is not None:
+            mask = np.asarray(self.non_fictitious).reshape(-1)
+            if mask.size == n_rows and not np.all(mask):
+                has_fictitious = True
+                index_values.append(("", ["" if m else "×" for m in mask]))
+
         rows, ellipsis_at = select_rows(n_rows)
 
         def take(cells: list[str]) -> list[str]:
@@ -230,7 +237,10 @@ class HyperEdgeSet(dict):
             columns = [(k, take(format_float_column(np.asarray(v).reshape(-1)))) for k, v in sorted(self.feature_dict.items())]
             groups.append(("features", columns))
 
-        return render_grouped_table(index_columns, groups, ellipsis_at=ellipsis_at)
+        lines = render_grouped_table(index_columns, groups, ellipsis_at=ellipsis_at)
+        if has_fictitious:
+            lines.append("× fictitious object")
+        return lines
 
     def __str__(self) -> str:
         return "\n".join([f"HyperEdgeSet · {self._summary()}", *self._table_lines()])

--- a/src/energnn/graph/structure.py
+++ b/src/energnn/graph/structure.py
@@ -4,8 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
 
-import pandas as pd
-
 HYPER_EDGE_SETS = "hyper_edge_sets"
 FEATURE_LIST = "feature_list"
 PORT_LIST = "port_list"
@@ -48,10 +46,16 @@ class GraphStructure(dict):
         return self[HYPER_EDGE_SETS]
 
     def __str__(self):
-        data = {
-            "Name": [edge_name for edge_name in self.hyper_edge_sets.keys()],
-            "Ports": [edge_structure.port_list for edge_structure in self.hyper_edge_sets.values()],
-            "Features": [edge_structure.feature_list for edge_structure in self.hyper_edge_sets.values()],
-        }
-        df = pd.DataFrame(data).set_index("Name")
-        return df.to_string()
+        items = list(self.hyper_edge_sets.items())
+        lines = [f"GraphStructure · {len(items)} hyper-edge set{'s' if len(items) != 1 else ''}"]
+        if not items:
+            return lines[0]
+
+        name_width = max(len(name) for name, _ in items)
+        port_cells = ["ports: " + (", ".join(s.port_list) if s.port_list else "—") for _, s in items]
+        port_width = max(len(cell) for cell in port_cells)
+        for i, ((name, structure), ports) in enumerate(zip(items, port_cells)):
+            branch = "└─ " if i == len(items) - 1 else "├─ "
+            features = "features: " + (", ".join(structure.feature_list) if structure.feature_list else "—")
+            lines.append(f"{branch}{name.ljust(name_width)}   {ports.ljust(port_width)}   {features}")
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

Replaces the pandas `DataFrame` reprs of `Graph`, `HyperEdgeSet` and `GraphStructure` with a small internal text-table renderer (`src/energnn/graph/formatting.py`):

- One-line summaries and a tree layout for `Graph`.
- Grouped ports/features columns in `HyperEdgeSet` tables, with head/tail truncation for large sets.
- Fictitious objects are marked with a `×` marker in `HyperEdgeSet` tables.
- The `energnn.graph` subpackage no longer depends on pandas.

Stacked on #106 (`graph-plot`) — only the last two commits are new here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)