### PR TITLE
Fix per-step retracing caused by NaN static attributes in normalizers

### DIFF
--- a/src/energnn/model/normalizer/center_reduce_normalizer.py
+++ b/src/energnn/model/normalizer/center_reduce_normalizer.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import logging
-import math
 
 import jax
 import jax.numpy as jnp
@@ -30,8 +29,8 @@ class HyperEdgeSetCenterReduceNormalizer(nnx.Module):
         epsilon: float = 1e-6,
         use_running_average: bool = False,
         saturation_strategy: str | None = None,
-        clip_min: float = float("nan"),
-        clip_max: float = float("nan"),
+        clip_min: float | None = None,
+        clip_max: float | None = None,
     ):
         """
         Initializes the instance with the necessary configurations and state variables for
@@ -52,7 +51,7 @@ class HyperEdgeSetCenterReduceNormalizer(nnx.Module):
         if saturation_strategy not in [None, "hard", "soft"]:
             raise ValueError(f"saturation_strategy must be None, 'hard' or 'soft', got {saturation_strategy}")
         if saturation_strategy == "hard":
-            if math.isnan(clip_min) or math.isnan(clip_max):
+            if clip_min is None or clip_max is None:
                 raise ValueError("clip_min and clip_max must be provided when saturation_strategy is 'hard'")
             if clip_min >= clip_max:
                 raise ValueError(f"clip_min must be strictly less than clip_max, got {clip_min} >= {clip_max}")
@@ -135,6 +134,8 @@ class HyperEdgeSetCenterReduceNormalizer(nnx.Module):
 
     def _apply_saturation(self, out: jax.Array) -> jax.Array:
         if self.saturation_strategy == "hard":
+            # Guaranteed by the __init__ validation; lets mypy narrow float | None to float
+            assert self.clip_min is not None and self.clip_max is not None
 
             # Warning mechanism only for hard clipping
             def log_clipping(has_clipped):
@@ -189,14 +190,14 @@ class CenterReduceNormalizer(Normalizer):
         epsilon: float = 1e-6,
         use_running_average: bool = False,
         saturation_strategy: str | None = None,
-        clip_min: float = float("nan"),
-        clip_max: float = float("nan"),
+        clip_min: float | None = None,
+        clip_max: float | None = None,
         return_metrics: bool = False,
     ):
         if saturation_strategy not in [None, "hard", "soft"]:
             raise ValueError(f"saturation_strategy must be None, 'hard' or 'soft', got {saturation_strategy}")
         if saturation_strategy == "hard":
-            if math.isnan(clip_min) or math.isnan(clip_max):
+            if clip_min is None or clip_max is None:
                 raise ValueError("clip_min and clip_max must be provided when saturation_strategy is 'hard'")
             if clip_min >= clip_max:
                 raise ValueError(f"clip_min must be strictly less than clip_max, got {clip_min} >= {clip_max}")

--- a/src/energnn/model/normalizer/tdigest_normalizer.py
+++ b/src/energnn/model/normalizer/tdigest_normalizer.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Sequence, Union
 import logging
@@ -329,8 +328,8 @@ class TDigestModule(nnx.Module):
         max_centroids: int,
         use_running_average: bool,
         saturation_strategy: str | None = None,
-        clip_min: float = float("nan"),
-        clip_max: float = float("nan"),
+        clip_min: float | None = None,
+        clip_max: float | None = None,
         update_frequency: int = 1,
     ):
         """
@@ -353,7 +352,7 @@ class TDigestModule(nnx.Module):
         if saturation_strategy not in [None, "hard", "soft"]:
             raise ValueError(f"saturation_strategy must be None, 'hard' or 'soft', got {saturation_strategy}")
         if saturation_strategy == "hard":
-            if math.isnan(clip_min) or math.isnan(clip_max):
+            if clip_min is None or clip_max is None:
                 raise ValueError("clip_min and clip_max must be provided when saturation_strategy is 'hard'")
             if clip_min >= clip_max:
                 raise ValueError(f"clip_min must be strictly less than clip_max, got {clip_min} >= {clip_max}")
@@ -485,6 +484,8 @@ class TDigestModule(nnx.Module):
 
     def _apply_saturation(self, out: jax.Array) -> jax.Array:
         if self.saturation_strategy == "hard":
+            # Guaranteed by the __init__ validation; lets mypy narrow float | None to float
+            assert self.clip_min is not None and self.clip_max is not None
 
             # Warning mechanism only for hard clipping
             def log_clipping(has_clipped):
@@ -519,8 +520,8 @@ class TDigestNormalizer(Normalizer):
         max_centroids: int = 1000,
         use_running_average: bool = False,
         saturation_strategy: str | None = None,
-        clip_min: float = float("nan"),
-        clip_max: float = float("nan"),
+        clip_min: float | None = None,
+        clip_max: float | None = None,
         update_frequency: int = 1,
         return_metrics: bool = False,
     ):
@@ -544,7 +545,7 @@ class TDigestNormalizer(Normalizer):
         if saturation_strategy not in [None, "hard", "soft"]:
             raise ValueError(f"saturation_strategy must be None, 'hard' or 'soft', got {saturation_strategy}")
         if saturation_strategy == "hard":
-            if math.isnan(clip_min) or math.isnan(clip_max):
+            if clip_min is None or clip_max is None:
                 raise ValueError("clip_min and clip_max must be provided when saturation_strategy is 'hard'")
             if clip_min >= clip_max:
                 raise ValueError(f"clip_min must be strictly less than clip_max, got {clip_min} >= {clip_max}")

--- a/tests/trainer/unit/test_simple_trainer.py
+++ b/tests/trainer/unit/test_simple_trainer.py
@@ -321,6 +321,45 @@ class TestJitCaching:
 
         assert counts == {"forward": 1, "backward": 1}
 
+    def test_ready_model_traced_once_across_steps(self, loader: LinearSystemProblemLoader, batch: ProblemBatch) -> None:
+        """The full ready-to-use model must not re-trace across steps.
+
+        Regression test: the TDigestModule used to store NaN static attributes (clip_min/clip_max),
+        and NaN != NaN made every graphdef comparison fail, forcing a re-trace and re-compile of
+        the forward and backward at every training step.
+        """
+        from energnn.model.ready_to_use import ReadyRecurrentEquivariantGNN
+
+        model = ReadyRecurrentEquivariantGNN(
+            in_structure=loader.context_structure,
+            out_structure=loader.decision_structure,
+            n_breakpoints=4,
+            latent_dimension=4,
+            hidden_sizes=[4],
+            n_steps=2,
+        )
+        counts = {"forward": 0, "backward": 0}
+        original_forward = Trainer._forward_vjp
+        original_backward = Trainer._backward_update
+
+        def counting_forward(*args, **kwargs):
+            counts["forward"] += 1
+            return original_forward(*args, **kwargs)
+
+        def counting_backward(*args, **kwargs):
+            counts["backward"] += 1
+            return original_backward(*args, **kwargs)
+
+        with (
+            mock.patch.object(Trainer, "_forward_vjp", staticmethod(counting_forward)),
+            mock.patch.object(Trainer, "_backward_update", staticmethod(counting_backward)),
+        ):
+            trainer = Trainer(model=model, gradient_transformation=optax.sgd(1e-3))
+            for _ in range(3):
+                trainer.training_step(batch, step_with_metrics=False)
+
+        assert counts == {"forward": 1, "backward": 1}
+
     def test_normalizer_updated_exactly_once_per_training_step(self, loader: LinearSystemProblemLoader) -> None:
         """The forward and the backward recomputation must not both commit normalizer state updates."""
         from energnn.model.ready_to_use import ReadyRecurrentEquivariantGNN


### PR DESCRIPTION
## Problem

#114 replaced the `clip_min`/`clip_max` defaults (`None`) with `float("nan")` in `TDigestModule`/`TDigestNormalizer` and `CenterReduceNormalizer` to satisfy mypy.

These attributes are **static** in the nnx graphdef, and since `NaN != NaN`, every graphdef equality check fails. The `nnx.jit` cache in the `Trainer` therefore never hits: the whole forward and backward are re-traced and **re-compiled at every training step**. Measured on the linear-system example (medium model, CPU): ~1.2 s/step instead of ~0.10 s (~12x slowdown), identical on GPU. The unbounded growth of compiled executables also leads to OOM on long runs (LLVM "Cannot allocate memory", SIGSEGV).

Every training run using the ready-to-use models (which embed a `TDigestNormalizer`) is affected since #114, on any hardware. Easy to spot with `JAX_LOG_COMPILES=1`: `Compiling jit(_forward_vjp)` appears at every step.

## Fix

- Restore `clip_min/clip_max: float | None = None` in both normalizers.
- Narrow with an `assert` in the `"hard"` saturation branch (guaranteed by the `__init__` validation) so mypy still passes.
- Add a regression test, `test_ready_model_traced_once_across_steps`, that trains `ReadyRecurrentEquivariantGNN` for 3 steps and asserts forward/backward are traced exactly once. The test fails on current main and passes with this fix.

More generally: never store NaN (or any object with non-reflexive equality) as a static attribute of an nnx module — the jit cache relies on graphdef equality.

## Checks

- `mypy src/energnn`: clean
- `flake8` (CI flags): clean
- `pytest tests/trainer tests/model/unit/test_tdigest_normalizer.py tests/model/unit/test_center_reduce_normalizer.py`: 54 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)